### PR TITLE
fix: update arguments must insert arguments if missing

### DIFF
--- a/pkg/snap/util/services.go
+++ b/pkg/snap/util/services.go
@@ -63,6 +63,7 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 		return fmt.Errorf("failed to read arguments of service %s: %w", serviceName, err)
 	}
 
+	existingArguments := make(map[string]struct{}, len(arguments))
 	newArguments := make([]string, 0, len(arguments))
 	for _, line := range strings.Split(arguments, "\n") {
 		line = strings.TrimSpace(line)
@@ -73,6 +74,7 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 		// handle "--argument value" and "--argument=value" variants
 		key := strings.SplitN(line, " ", 2)[0]
 		key = strings.SplitN(key, "=", 2)[0]
+		existingArguments[key] = struct{}{}
 		if newValue, ok := updateMap[key]; ok {
 			// update argument with new value
 			newArguments = append(newArguments, fmt.Sprintf("%s=%s", key, newValue))
@@ -82,6 +84,12 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 		} else {
 			// no change
 			newArguments = append(newArguments, line)
+		}
+	}
+
+	for key, value := range updateMap {
+		if _, argExists := existingArguments[key]; !argExists {
+			newArguments = append(newArguments, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
 

--- a/pkg/snap/util/services_test.go
+++ b/pkg/snap/util/services_test.go
@@ -96,6 +96,13 @@ func TestUpdateServiceArguments(t *testing.T) {
 				"--key": "value",
 			},
 		},
+		{
+			name:   "new-opt",
+			update: []map[string]string{{"--new-opt": "opt-value"}},
+			expectedValues: map[string]string{
+				"--new-opt": "opt-value",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &mock.Snap{


### PR DESCRIPTION
### Summary

This fixes a bug where the `/v1/configure` endpoint was refusing to add new arguments to the config file.

### Notes

Added a unit test to check for this case as well.