### PR TITLE
Persistent Cluster Tokens

### DIFF
--- a/pkg/api/v1/configure.go
+++ b/pkg/api/v1/configure.go
@@ -43,7 +43,7 @@ type ConfigureRequest struct {
 
 // Configure implements "POST /CLUSTER_API_V1/configure".
 func (a *API) Configure(ctx context.Context, req ConfigureRequest) error {
-	if !a.Snap.IsValidSelfCallbackToken(req.CallbackToken) {
+	if !a.Snap.ConsumeSelfCallbackToken(req.CallbackToken) {
 		return fmt.Errorf("invalid token")
 	}
 	for _, service := range req.ConfigureServices {

--- a/pkg/api/v1/join.go
+++ b/pkg/api/v1/join.go
@@ -44,11 +44,8 @@ type JoinResponse struct {
 
 // Join implements "POST /CLUSTER_API_V1/join".
 func (a *API) Join(ctx context.Context, request JoinRequest) (*JoinResponse, error) {
-	if !a.Snap.IsValidClusterToken(request.ClusterToken) {
+	if !a.Snap.ConsumeClusterToken(request.ClusterToken) {
 		return nil, fmt.Errorf("invalid token")
-	}
-	if err := a.Snap.RemoveClusterToken(request.ClusterToken); err != nil {
-		return nil, fmt.Errorf("failed to remove cluster token: %w", err)
 	}
 
 	if a.Snap.HasDqliteLock() {

--- a/pkg/api/v1/join_test.go
+++ b/pkg/api/v1/join_test.go
@@ -39,6 +39,9 @@ func TestJoin(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected an error due to invalid token, but did not get any")
 		}
+		if !reflect.DeepEqual(s.ConsumeClusterTokenCalledWith, []string{"invalid-token"}) {
+			t.Fatalf("Expected ConsumeClusterToken to be called with %v, but it was called with %v instead", []string{"invalid-token"}, s.ConsumeClusterTokenCalledWith)
+		}
 	})
 
 	t.Run("Dqlite", func(t *testing.T) {
@@ -56,7 +59,7 @@ func TestJoin(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		s.RemoveClusterTokenCalledWith = nil
+		s.ConsumeClusterTokenCalledWith = nil
 		resp, err := apiv1.Join(context.Background(), v1.JoinRequest{
 			ClusterToken:     "valid-cluster-token",
 			HostName:         "my-hostname",
@@ -85,8 +88,8 @@ func TestJoin(t *testing.T) {
 		if len(resp.KubeletToken) != 32 {
 			t.Fatalf("Expected kubelet token %q to have length 32", resp.KubeletToken)
 		}
-		if !reflect.DeepEqual(s.RemoveClusterTokenCalledWith, []string{"valid-cluster-token"}) {
-			t.Fatalf("Expected RemoveClusterToken to be called with %v, but it was called with %v instead", []string{"valid-cluster-token"}, s.RemoveClusterTokenCalledWith)
+		if !reflect.DeepEqual(s.ConsumeClusterTokenCalledWith, []string{"valid-cluster-token"}) {
+			t.Fatalf("Expected ConsumeClusterToken to be called with %v, but it was called with %v instead", []string{"valid-cluster-token"}, s.ConsumeClusterTokenCalledWith)
 		}
 		if !reflect.DeepEqual(s.RestartServiceCalledWith, []string{"apiserver"}) {
 			t.Fatalf("Expected API server restart command, but got %v instead", s.RestartServiceCalledWith)

--- a/pkg/api/v1/sign_cert.go
+++ b/pkg/api/v1/sign_cert.go
@@ -21,11 +21,8 @@ type SignCertResponse struct {
 
 // SignCert implements "POST CLUSTER_API_V1/sign-cert".
 func (a *API) SignCert(ctx context.Context, req SignCertRequest) (*SignCertResponse, error) {
-	if !a.Snap.IsValidCertificateRequestToken(req.Token) {
+	if !a.Snap.ConsumeCertificateRequestToken(req.Token) {
 		return nil, fmt.Errorf("invalid token")
-	}
-	if err := a.Snap.RemoveCertificateRequestToken(req.Token); err != nil {
-		return nil, fmt.Errorf("failed to remove certificate request token: %w", err)
 	}
 
 	cert, err := a.Snap.SignCertificate(ctx, []byte(req.CertificateSigningRequest))

--- a/pkg/api/v1/sign_cert_test.go
+++ b/pkg/api/v1/sign_cert_test.go
@@ -25,9 +25,15 @@ func TestSignCert(t *testing.T) {
 		if resp != nil {
 			t.Fatalf("Expected a nil response but received %#v", resp)
 		}
+		expectedConsumeCertificateRequestTokenCalledWith := []string{"invalid-token"}
+		if !reflect.DeepEqual(expectedConsumeCertificateRequestTokenCalledWith, s.ConsumeCertificateRequestTokenCalledWith) {
+			t.Fatalf("Expected ConsumeCertificateRequestToken to be called with %v, but it was called with %v instead", expectedConsumeCertificateRequestTokenCalledWith, s.ConsumeCertificateRequestTokenCalledWith)
+		}
 	})
 
 	t.Run("Success", func(t *testing.T) {
+		s.ConsumeCertificateRequestTokenCalledWith = nil
+
 		resp, err := apiv1.SignCert(context.Background(), v1.SignCertRequest{
 			Token:                     "valid-token",
 			CertificateSigningRequest: "CSR DATA",
@@ -42,9 +48,9 @@ func TestSignCert(t *testing.T) {
 		if !reflect.DeepEqual(expectedCalledWith, s.SignCertificateCalledWith) {
 			t.Fatalf("Expected SignCertificate called with %v, but it was called with %v instead", expectedCalledWith, s.SignCertificateCalledWith)
 		}
-		expectedRemoveCertificateRequestTokenCalledWith := []string{"valid-token"}
-		if !reflect.DeepEqual(expectedRemoveCertificateRequestTokenCalledWith, s.RemoveCertificateRequestTokenCalledWith) {
-			t.Fatalf("Expected RemoveCertificateRequestToken to be called with %v, but it was called with %v instead", expectedRemoveCertificateRequestTokenCalledWith, s.RemoveCertificateRequestTokenCalledWith)
+		expectedConsumeCertificateRequestTokenCalledWith := []string{"valid-token"}
+		if !reflect.DeepEqual(expectedConsumeCertificateRequestTokenCalledWith, s.ConsumeCertificateRequestTokenCalledWith) {
+			t.Fatalf("Expected ConsumeCertificateRequestToken to be called with %v, but it was called with %v instead", expectedConsumeCertificateRequestTokenCalledWith, s.ConsumeCertificateRequestTokenCalledWith)
 		}
 		if resp.Certificate != s.SignedCertificate {
 			t.Fatalf("Expected ceritificate to be %q, but it was %q instead", s.SignedCertificate, resp.Certificate)

--- a/pkg/api/v1/upgrade.go
+++ b/pkg/api/v1/upgrade.go
@@ -19,7 +19,7 @@ type UpgradeRequest struct {
 
 // Upgrade implements "POST v1/upgrade".
 func (a *API) Upgrade(ctx context.Context, req UpgradeRequest) error {
-	if !a.Snap.IsValidSelfCallbackToken(req.CallbackToken) {
+	if !a.Snap.ConsumeSelfCallbackToken(req.CallbackToken) {
 		return fmt.Errorf("invalid token")
 	}
 	if err := a.Snap.RunUpgrade(ctx, req.UpgradeName, req.UpgradePhase); err != nil {

--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -79,11 +79,8 @@ type JoinResponse struct {
 // Join implements "POST v2/join".
 // Join returns the join response on success, otherwise an error and the HTTP status code.
 func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, error) {
-	if !a.Snap.IsValidClusterToken(req.ClusterToken) {
+	if !a.Snap.ConsumeClusterToken(req.ClusterToken) {
 		return nil, http.StatusInternalServerError, fmt.Errorf("invalid token")
-	}
-	if err := a.Snap.RemoveClusterToken(req.ClusterToken); err != nil {
-		return nil, http.StatusInternalServerError, fmt.Errorf("failed to remove cluster token: %w", err)
 	}
 	if !a.Snap.HasDqliteLock() {
 		return nil, http.StatusNotImplemented, fmt.Errorf("not possible to join. This is not an HA MicroK8s cluster")

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -67,9 +67,13 @@ Role: 0
 		if resp != nil {
 			t.Fatalf("Expected a nil response but received %#v", resp)
 		}
+		if !reflect.DeepEqual(s.ConsumeClusterTokenCalledWith, []string{"invalid-token"}) {
+			t.Fatalf("Expected ConsumeClusterToken to be called with %v, but it was called with %v instead", []string{"invalid-token"}, s.ConsumeClusterTokenCalledWith)
+		}
 	})
 
 	t.Run("ControlPlane", func(t *testing.T) {
+		s.ConsumeClusterTokenCalledWith = nil
 		resp, _, err := apiv2.Join(context.Background(), v2.JoinRequest{
 			ClusterToken:     "control-plane-token",
 			RemoteHostName:   "test-control-plane",
@@ -102,8 +106,8 @@ Role: 0
 		if !reflect.DeepEqual(*resp, *expectedResponse) {
 			t.Fatalf("Expected response %#v, but received %#v instead", expectedResponse, resp)
 		}
-		if !reflect.DeepEqual(s.RemoveClusterTokenCalledWith, []string{"control-plane-token"}) {
-			t.Fatalf("Expected RemoveClusterToken to be called with %v, but it was called with %v instead", []string{"control-plane-token"}, s.RemoveClusterTokenCalledWith)
+		if !reflect.DeepEqual(s.ConsumeClusterTokenCalledWith, []string{"control-plane-token"}) {
+			t.Fatalf("Expected ConsumeClusterToken to be called with %v, but it was called with %v instead", []string{"control-plane-token"}, s.ConsumeClusterTokenCalledWith)
 		}
 
 		if len(s.ApplyCNICalled) != 1 {
@@ -116,7 +120,7 @@ Role: 0
 
 	t.Run("Worker", func(t *testing.T) {
 		// Reset
-		s.RemoveClusterTokenCalledWith = nil
+		s.ConsumeClusterTokenCalledWith = nil
 		s.ApplyCNICalled = nil
 		s.CreateNoCertsReissueLockCalledWith = nil
 
@@ -147,8 +151,8 @@ Role: 0
 		if !reflect.DeepEqual(*resp, *expectedResponse) {
 			t.Fatalf("Expected response %#v, but received %#v instead", expectedResponse, resp)
 		}
-		if !reflect.DeepEqual(s.RemoveClusterTokenCalledWith, []string{"worker-token"}) {
-			t.Fatalf("Expected RemoveClusterToken to be called with %v, but it was called with %v instead", []string{"worker-token"}, s.RemoveClusterTokenCalledWith)
+		if !reflect.DeepEqual(s.ConsumeClusterTokenCalledWith, []string{"worker-token"}) {
+			t.Fatalf("Expected ConsumeClusterToken to be called with %v, but it was called with %v instead", []string{"worker-token"}, s.ConsumeClusterTokenCalledWith)
 		}
 		expectedCertRequestTokens := []string{"worker-token-kubelet", "worker-token-proxy"}
 		if !reflect.DeepEqual(s.AddCertificateRequestTokenCalledWith, expectedCertRequestTokens) {
@@ -243,8 +247,8 @@ Role: 0
 	if !reflect.DeepEqual(*resp, *expectedResponse) {
 		t.Fatalf("Expected response %#v, but received %#v instead", expectedResponse, resp)
 	}
-	if !reflect.DeepEqual(s.RemoveClusterTokenCalledWith, []string{"control-plane-token"}) {
-		t.Fatalf("Expected RemoveClusterToken to be called with %v, but it was called with %v instead", []string{"control-plane-token"}, s.RemoveClusterTokenCalledWith)
+	if !reflect.DeepEqual(s.ConsumeClusterTokenCalledWith, []string{"control-plane-token"}) {
+		t.Fatalf("Expected ConsumeClusterToken to be called with %v, but it was called with %v instead", []string{"control-plane-token"}, s.ConsumeClusterTokenCalledWith)
 	}
 	expectedUpdate := []string{"Address: 10.10.10.10:19001\n"}
 	if !reflect.DeepEqual(s.WriteDqliteUpdateYamlCalledWith, expectedUpdate) {

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -61,22 +61,20 @@ type Snap interface {
 	// WriteServiceArguments updates the arguments file a particular service.
 	WriteServiceArguments(serviceName string, b []byte) error
 
-	// IsValidClusterToken returns true if token is a valid token for authenticating join requests.
-	IsValidClusterToken(token string) bool
-	// IsValidCertificateRequestToken returns true if token is a valid token for authenticating certificate signing requests.
-	IsValidCertificateRequestToken(token string) bool
-	// IsValidSelfCallbackToken returns true if token is a valid token for authenticating configure and upgrade requests.
-	IsValidSelfCallbackToken(token string) bool
+	// ConsumeClusterToken returns true if token is a valid token for authenticating join requests.
+	// Tokens with a TTL may be consumed multiple times until they expire. One-time tokens may only be consumed once.
+	ConsumeClusterToken(token string) bool
+	// ConsumeCertificateRequestToken returns true if token is a valid token for authenticating certificate signing requests.
+	// Certificate request tokens may only be consumed once.
+	ConsumeCertificateRequestToken(token string) bool
+	// ConsumeSelfCallbackToken returns true if token is a valid token for authenticating configure and upgrade requests.
+	// Self callback tokens may be consumed multiple times.
+	ConsumeSelfCallbackToken(token string) bool
 
 	// AddCertificateRequestToken adds a new token that can be used to authenticate certificate signing requests.
 	AddCertificateRequestToken(token string) error
 	// AddCallbackToken adds a new token that can be used to authenticate requests to a remote cluster agent endpoint.
 	AddCallbackToken(clusterAgentEndpoint, token string) error
-
-	// RemoveClusterToken removes a cluster token. It should be called after the token has been used.
-	RemoveClusterToken(token string) error
-	// RemoveCertificateRequest removes a certificate request token. It should be called after the token has been used.
-	RemoveCertificateRequestToken(token string) error
 
 	// GetOrCreateSelfCallbackToken creates and returns the callback token that can be used for configure and upgrade requests to this cluster agent.
 	// Subsequent calls should return the same token.

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -49,8 +49,8 @@ type Snap struct {
 	AddCertificateRequestTokenCalledWith []string
 	AddCallbackTokenCalledWith           []string // "{clusterAgentEndpoint} {token}"
 
-	RemoveClusterTokenCalledWith            []string
-	RemoveCertificateRequestTokenCalledWith []string
+	ConsumeClusterTokenCalledWith            []string
+	ConsumeCertificateRequestTokenCalledWith []string
 
 	SelfCallbackToken string
 	KubeletTokens     map[string]string // map hostname to token
@@ -195,18 +195,27 @@ func contains(list []string, item string) bool {
 	return false
 }
 
-// IsValidClusterToken is a mock implementation for the snap.Snap interface.
-func (s *Snap) IsValidClusterToken(token string) bool {
+// ConsumeClusterToken is a mock implementation for the snap.Snap interface.
+func (s *Snap) ConsumeClusterToken(token string) bool {
+	if s.ConsumeClusterTokenCalledWith == nil {
+		s.ConsumeClusterTokenCalledWith = make([]string, 0, 1)
+	}
+	s.ConsumeClusterTokenCalledWith = append(s.ConsumeClusterTokenCalledWith, token)
 	return contains(s.ClusterTokens, token)
 }
 
-// IsValidCertificateRequestToken is a mock implementation for the snap.Snap interface.
-func (s *Snap) IsValidCertificateRequestToken(token string) bool {
+// ConsumeCertificateRequestToken is a mock implementation for the snap.Snap interface.
+func (s *Snap) ConsumeCertificateRequestToken(token string) bool {
+	if s.ConsumeCertificateRequestTokenCalledWith == nil {
+		s.ConsumeCertificateRequestTokenCalledWith = make([]string, 0, 1)
+	}
+
+	s.ConsumeCertificateRequestTokenCalledWith = append(s.ConsumeCertificateRequestTokenCalledWith, token)
 	return contains(s.CertificateRequestTokens, token)
 }
 
-// IsValidSelfCallbackToken is a mock implementation for the snap.Snap interface.
-func (s *Snap) IsValidSelfCallbackToken(token string) bool {
+// ConsumeSelfCallbackToken is a mock implementation for the snap.Snap interface.
+func (s *Snap) ConsumeSelfCallbackToken(token string) bool {
 	return contains(s.SelfCallbackTokens, token)
 }
 
@@ -232,21 +241,11 @@ func (s *Snap) AddCallbackToken(clusterAgentEndpoint string, token string) error
 
 // RemoveClusterToken is a mock implementation for the snap.Snap interface.
 func (s *Snap) RemoveClusterToken(token string) error {
-	if s.RemoveClusterTokenCalledWith == nil {
-		s.RemoveClusterTokenCalledWith = make([]string, 0, 1)
+	if s.ConsumeClusterTokenCalledWith == nil {
+		s.ConsumeClusterTokenCalledWith = make([]string, 0, 1)
 	}
 
-	s.RemoveClusterTokenCalledWith = append(s.RemoveClusterTokenCalledWith, token)
-	return nil
-}
-
-// RemoveCertificateRequestToken is a mock implementation for the snap.Snap interface.
-func (s *Snap) RemoveCertificateRequestToken(token string) error {
-	if s.RemoveCertificateRequestTokenCalledWith == nil {
-		s.RemoveCertificateRequestTokenCalledWith = make([]string, 0, 1)
-	}
-
-	s.RemoveCertificateRequestTokenCalledWith = append(s.RemoveCertificateRequestTokenCalledWith, token)
+	s.ConsumeClusterTokenCalledWith = append(s.ConsumeClusterTokenCalledWith, token)
 	return nil
 }
 

--- a/pkg/snap/snap_token_test.go
+++ b/pkg/snap/snap_token_test.go
@@ -58,6 +58,9 @@ token-not-expired|%d
 		{token: "token-not-expired", expectedValid: true},
 		{token: "token-not-expired", expectedValid: true},
 		{token: "token-not-expired", expectedValid: true},
+
+		// tokens with '|' are invalid
+		{token: "token-invalid-timestamp|-10a", expectedValid: false},
 	} {
 		t.Run(tc.token, func(t *testing.T) {
 			if s.ConsumeClusterToken(tc.token) != tc.expectedValid {

--- a/pkg/util/token.go
+++ b/pkg/util/token.go
@@ -41,12 +41,12 @@ func NewRandomString(letters RandomCharacters, length int) string {
 // For example, the tokens file may look like this:
 //
 //     token1
-//     token2 35616531876
+//     token2|35616531876
 //
 // In the file above, token1 is a valid token. token2 is valid until the unix timestamp 35616531876.
-func IsValidToken(token string, tokensFile string) bool {
+func IsValidToken(token string, tokensFile string) (isValidToken, hasTTL bool) {
 	if token == "" {
-		return false
+		return false, false
 	}
 	token = strings.TrimSpace(token)
 	if b, err := os.ReadFile(tokensFile); err == nil {
@@ -57,19 +57,19 @@ func IsValidToken(token string, tokensFile string) bool {
 				continue
 			}
 			if len(parts) == 1 {
-				return true
+				return true, false
 			}
 			// token with expiry
 			if len(parts) == 2 {
 				timestamp, err := strconv.ParseInt(parts[1], 10, 64)
 				if err != nil {
-					return false
+					return false, true
 				}
-				return time.Now().Before(time.Unix(timestamp, 0))
+				return time.Now().Before(time.Unix(timestamp, 0)), true
 			}
 		}
 	}
-	return false
+	return false, false
 }
 
 // AppendToken appends a token to a file.


### PR DESCRIPTION
### Summary

Update cluster-agent to support tokens with a specific TTL limit. Previously, TTL tokens were treated similar to one-time tokens and removed after use.

### Notes

- Updated the `snap.Snap` interface to reflect that we may _consume_ tokens multiple times.
- Added new unit tests to ensure token validity (tokens with TTL may be reused)
- Updated the v1 and v2 API accordingly
