### PR TITLE
Image Side-loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,37 @@ make go.fmt go.lint go.test go.vet go.staticcheck
 make cluster-agent
 ./cluster-agent --help
 ```
+
+## Testing with live MicroK8s instance
+
+### MicroK8s running on local machine
+
+```bash
+cd cluster-agent
+sudo snap download microk8s --basename=microk8s
+sudo unsquashfs ./microk8s.snap
+sudo chown -R 1000: squashfs-root
+sudo sed 's,$SNAP/bin/cluster-agent,go run '"$PWD"',' -i squashfs-root/run-cluster-agent-with-args
+
+# development iteration
+sudo snap restart microk8s.daemon-cluster-agent
+```
+
+### MicroK8s running on remote machine
+
+```bash
+export HOST=ubuntu@10.0.0.100
+
+ssh $HOST '
+    sudo snap download microk8s --basename=microk8s
+    sudo unsquashfs microk8s.snap
+    sudo chown -R 1000: squashfs-root
+    sudo snap try ./squashfs-root
+'
+
+# development iteration
+go build .
+ssh $HOST 'sudo snap stop microk8s.daemon-cluster-agent'
+scp ./microk8s-cluster-agent $HOST:squashfs-root/bin/cluster-agent
+ssh $HOST 'sudo snap start microk8s.daemon-cluster-agent'
+```

--- a/pkg/api/v2/image.go
+++ b/pkg/api/v2/image.go
@@ -1,0 +1,40 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+// ImageImportRequest is a request for importing an image to the container runtime.
+type ImageImportRequest struct {
+	// Token is the certificate request token.
+	Token string
+	// ImageDataReader is an io.Reader that fetches the OCI image tarball bytes.
+	// ImageDataReader is a reader interface instead of a bytes buffer to avoid reading
+	// the contents of the image when the token is invalid.
+	ImageDataReader io.Reader
+}
+
+// ImageImport implements "POST CLUSTER_API_V2/images/import"
+func (a *API) ImageImport(ctx context.Context, req *ImageImportRequest) error {
+	if !a.Snap.ConsumeSelfCallbackToken(req.Token) {
+		return fmt.Errorf("invalid token")
+	}
+
+	if req.ImageDataReader == nil {
+		return fmt.Errorf("no image data")
+	}
+	b, err := ioutil.ReadAll(req.ImageDataReader)
+	if err != nil {
+		return fmt.Errorf("failed to read the image data contents: %w", err)
+	}
+
+	// TODO(neoaggelos): we might want to ignore the errors
+	if err := a.Snap.ImportImage(ctx, b); err != nil {
+		return fmt.Errorf("failed to import the image: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/api/v2/image.go
+++ b/pkg/api/v2/image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -27,13 +26,9 @@ func (a *API) ImageImport(ctx context.Context, req *ImageImportRequest) (int, er
 	if req.ImageDataReader == nil {
 		return http.StatusBadRequest, fmt.Errorf("no image data")
 	}
-	b, err := ioutil.ReadAll(req.ImageDataReader)
-	if err != nil {
-		return http.StatusBadRequest, fmt.Errorf("failed to read the image data contents: %w", err)
-	}
 
 	// TODO(neoaggelos): we might want to ignore the errors
-	if err := a.Snap.ImportImage(ctx, b); err != nil {
+	if err := a.Snap.ImportImage(ctx, req.ImageDataReader); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to import the image: %w", err)
 	}
 

--- a/pkg/api/v2/image_test.go
+++ b/pkg/api/v2/image_test.go
@@ -1,0 +1,56 @@
+package v2_test
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"testing"
+
+	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
+)
+
+func TestImageImport(t *testing.T) {
+	s := &mock.Snap{
+		SelfCallbackTokens: []string{"valid-token"},
+	}
+
+	apiv2 := &v2.API{Snap: s}
+
+	t.Run("InvalidToken", func(t *testing.T) {
+		reader := &recordingReader{
+			Reader: bytes.NewBufferString("IMAGEDATA"),
+		}
+		err := apiv2.ImageImport(context.Background(), &v2.ImageImportRequest{
+			Token:           "invalid-token",
+			ImageDataReader: reader,
+		})
+		if err == nil {
+			t.Fatal("Expected an error but did not receive any")
+		}
+		if len(reader.CountReadBytes) > 0 {
+			t.Fatalf("Expected no Read calls for the image contents, but got one")
+		}
+	})
+
+	t.Run("ValidToken", func(t *testing.T) {
+		reader := &recordingReader{
+			Reader: bytes.NewBufferString("IMAGEDATA"),
+		}
+		err := apiv2.ImageImport(context.Background(), &v2.ImageImportRequest{
+			Token:           "valid-token",
+			ImageDataReader: reader,
+		})
+		if err != nil {
+			t.Fatalf("Expected no errors but received %q", err)
+		}
+		if len(reader.CountReadBytes) == 0 {
+			t.Fatalf("Expected Read calls for the image contents, but did not get any")
+		}
+
+		expectedImportImage := []string{"IMAGEDATA"}
+		if importedImages := s.ImportImageCalledWith; !reflect.DeepEqual(expectedImportImage, importedImages) {
+			t.Fatalf("Expected ImportImage to be called with %q, but it was called with %q instead", expectedImportImage, importedImages)
+		}
+	})
+}

--- a/pkg/api/v2/image_test.go
+++ b/pkg/api/v2/image_test.go
@@ -3,6 +3,7 @@ package v2_test
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -21,12 +22,15 @@ func TestImageImport(t *testing.T) {
 		reader := &recordingReader{
 			Reader: bytes.NewBufferString("IMAGEDATA"),
 		}
-		err := apiv2.ImageImport(context.Background(), &v2.ImageImportRequest{
+		rc, err := apiv2.ImageImport(context.Background(), &v2.ImageImportRequest{
 			Token:           "invalid-token",
 			ImageDataReader: reader,
 		})
 		if err == nil {
 			t.Fatal("Expected an error but did not receive any")
+		}
+		if rc < 400 {
+			t.Fatalf("Expected an error response code but received %v", rc)
 		}
 		if len(reader.CountReadBytes) > 0 {
 			t.Fatalf("Expected no Read calls for the image contents, but got one")
@@ -37,12 +41,15 @@ func TestImageImport(t *testing.T) {
 		reader := &recordingReader{
 			Reader: bytes.NewBufferString("IMAGEDATA"),
 		}
-		err := apiv2.ImageImport(context.Background(), &v2.ImageImportRequest{
+		rc, err := apiv2.ImageImport(context.Background(), &v2.ImageImportRequest{
 			Token:           "valid-token",
 			ImageDataReader: reader,
 		})
 		if err != nil {
 			t.Fatalf("Expected no errors but received %q", err)
+		}
+		if rc != http.StatusOK {
+			t.Fatalf("Expected an HTTP 200 response code, but received %v", rc)
 		}
 		if len(reader.CountReadBytes) == 0 {
 			t.Fatalf("Expected Read calls for the image contents, but did not get any")

--- a/pkg/api/v2/mock_test.go
+++ b/pkg/api/v2/mock_test.go
@@ -2,6 +2,7 @@ package v2_test
 
 import (
 	"context"
+	"io"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 )
@@ -11,3 +12,20 @@ func mockListControlPlaneNodes(nodes ...string) func(context.Context, snap.Snap)
 		return nodes, nil
 	}
 }
+
+// recordingReader wraps an io.Reader and records Read function calls.
+type recordingReader struct {
+	io.Reader
+	CountReadBytes []int
+}
+
+func (r *recordingReader) Read(p []byte) (int, error) {
+	if r.CountReadBytes == nil {
+		r.CountReadBytes = make([]int, 0, 1)
+	}
+	n, err := r.Reader.Read(p)
+	r.CountReadBytes = append(r.CountReadBytes, n)
+	return n, err
+}
+
+var _ io.Reader = &recordingReader{}

--- a/pkg/api/v2/register.go
+++ b/pkg/api/v2/register.go
@@ -34,4 +34,23 @@ func (a *API) RegisterServer(server *http.ServeMux, middleware func(f http.Handl
 		}
 		httputil.Response(w, response)
 	}))
+
+	// POST v2/image/import
+	server.HandleFunc(fmt.Sprintf("%s/image/import", HTTPPrefix), middleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		req := &ImageImportRequest{
+			Token:           r.Header.Get("x-microk8s-callback-token"),
+			ImageDataReader: r.Body,
+		}
+		rc, err := a.ImageImport(r.Context(), req)
+		if err != nil {
+			httputil.Error(w, rc, err)
+			return
+		}
+		httputil.Response(w, map[string]string{"status": "OK"})
+	}))
 }

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -2,6 +2,7 @@ package snap
 
 import (
 	"context"
+	"io"
 )
 
 // Snap is how the cluster agent interacts with the snap.
@@ -89,5 +90,5 @@ type Snap interface {
 	SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, error)
 
 	// ImportImage imports an OCI image from raw bytes.
-	ImportImage(ctx context.Context, image []byte) error
+	ImportImage(ctx context.Context, reader io.Reader) error
 }

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -87,4 +87,7 @@ type Snap interface {
 
 	// SignCertificate signs the certificate signing request, and returns the certificate in PEM format.
 	SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, error)
+
+	// ImportImage imports an OCI image from raw bytes.
+	ImportImage(ctx context.Context, image []byte) error
 }

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -58,6 +58,8 @@ type Snap struct {
 
 	SignCertificateCalledWith []string // string(csrPEM)
 	SignedCertificate         string
+
+	ImportImageCalledWith []string // string(image)
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.
@@ -294,6 +296,15 @@ func (s *Snap) SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, erro
 	}
 	s.SignCertificateCalledWith = append(s.SignCertificateCalledWith, string(csrPEM))
 	return []byte(s.SignedCertificate), nil
+}
+
+// ImportImage is a mock implementation for the snap.Snap interface.
+func (s *Snap) ImportImage(ctx context.Context, image []byte) error {
+	if s.ImportImageCalledWith == nil {
+		s.ImportImageCalledWith = make([]string, 0, 1)
+	}
+	s.ImportImageCalledWith = append(s.ImportImageCalledWith, string(image))
+	return nil
 }
 
 var _ snap.Snap = &Snap{}

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -3,6 +3,8 @@ package mock
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	"github.com/canonical/microk8s-cluster-agent/pkg/util"
@@ -59,7 +61,7 @@ type Snap struct {
 	SignCertificateCalledWith []string // string(csrPEM)
 	SignedCertificate         string
 
-	ImportImageCalledWith []string // string(image)
+	ImportImageCalledWith []string // string(io.ReadAll(reader))
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.
@@ -299,11 +301,12 @@ func (s *Snap) SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, erro
 }
 
 // ImportImage is a mock implementation for the snap.Snap interface.
-func (s *Snap) ImportImage(ctx context.Context, image []byte) error {
+func (s *Snap) ImportImage(ctx context.Context, reader io.Reader) error {
 	if s.ImportImageCalledWith == nil {
 		s.ImportImageCalledWith = make([]string, 0, 1)
 	}
-	s.ImportImageCalledWith = append(s.ImportImageCalledWith, string(image))
+	b, _ := ioutil.ReadAll(reader)
+	s.ImportImageCalledWith = append(s.ImportImageCalledWith, string(b))
 	return nil
 }
 

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -2,9 +2,11 @@ package snap
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
-	"os"
 	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -204,10 +206,10 @@ func (s *snap) ConsumeCertificateRequestToken(token string) bool {
 	certRequestTokensFile := s.snapDataPath("credentials", "certs-request-tokens.txt")
 	isValid, _ := util.IsValidToken(token, certRequestTokensFile)
 	if isValid {
-	if err := util.RemoveToken(token, certRequestTokensFile, s.GetGroupName()); err != nil {
-		log.Printf("Failed to remove certificate request token: %v", err)
+		if err := util.RemoveToken(token, certRequestTokensFile, s.GetGroupName()); err != nil {
+			log.Printf("Failed to remove certificate request token: %v", err)
+		}
 	}
-}
 	return isValid
 }
 
@@ -291,6 +293,16 @@ func (s *snap) SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, erro
 	}
 
 	return certificateBytes, nil
+}
+
+func (s *snap) ImportImage(ctx context.Context, image []byte) error {
+	microk8sCtr := s.snapPath("microk8s-ctr.wrapper")
+	path := s.snapDataPath(fmt.Sprintf("image-%s.tar", hex.EncodeToString(sha256.New().Sum(image))))
+	err := s.runCommand(ctx, microk8sCtr, "image", "import", path)
+	if err != nil {
+		return fmt.Errorf("microk8s.ctr command failed: %w", err)
+	}
+	return nil
 }
 
 var _ Snap = &snap{}

--- a/pkg/snap/snap_images_test.go
+++ b/pkg/snap/snap_images_test.go
@@ -1,9 +1,10 @@
 package snap_test
 
 import (
+	"bytes"
 	"context"
-	"fmt"
-	"reflect"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
@@ -11,24 +12,39 @@ import (
 	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
 )
 
+var mockCtr = `#!/bin/bash
+
+# this is a mock for the $SNAP/microk8s-ctr.wrapper script, used to
+# ensure that cluster-agent is calling it properly
+
+echo $0 $@ > testdata/arguments
+cat > testdata/stdin
+`
+
 func TestImportImage(t *testing.T) {
+	if err := os.WriteFile("testdata/microk8s-ctr.wrapper", []byte(mockCtr), 0755); err != nil {
+		t.Fatalf("Failed to initialize mock ctr command: %v", err)
+	}
+	defer func() {
+		os.Remove("testdata/microk8s-ctr.wrapper")
+		os.Remove("testdata/stdin")
+		os.Remove("testdata/arguments")
+	}()
 	mockRunner := &utiltest.MockRunner{}
 	s := snap.NewSnap("testdata", "testdata", mockRunner.Run)
 
-	err := s.ImportImage(context.Background(), []byte(`IMAGEDATA`))
+	err := s.ImportImage(context.Background(), bytes.NewBufferString("IMAGEDATA"))
 	if err != nil {
 		t.Fatalf("Expected no error but got %q instead", err)
 	}
 
-	// hex of SHA256("IMAGEDATA")
-	expectedFilename := "testdata/image-494d41474544415441e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.tar"
-
-	expectedCmd := []string{fmt.Sprintf("testdata/microk8s-ctr.wrapper image import %s", expectedFilename)}
-	if cmd := mockRunner.CalledWithCommand; !reflect.DeepEqual(cmd, expectedCmd) {
-		t.Fatalf("Expected command %q but received %q instead", expectedCmd, cmd)
+	expectedCmd := "testdata/microk8s-ctr.wrapper image import -"
+	if cmd, err := util.ReadFile("testdata/arguments"); err != nil || strings.TrimSpace(cmd) != "testdata/microk8s-ctr.wrapper image import -" {
+		t.Fatalf("Expected command to be %q but it was %q instead", expectedCmd, cmd)
 	}
 
-	if util.FileExists(expectedFilename) {
-		t.Fatalf("Expected file %q to not exist after image import, but it was not", expectedFilename)
+	expectedStdin := "IMAGEDATA"
+	if stdin, err := util.ReadFile("testdata/stdin"); err != nil || stdin != "IMAGEDATA" {
+		t.Fatalf("Expected stdin to be %q but it was %q instead", expectedStdin, stdin)
 	}
 }

--- a/pkg/snap/snap_images_test.go
+++ b/pkg/snap/snap_images_test.go
@@ -1,0 +1,34 @@
+package snap_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
+	"github.com/canonical/microk8s-cluster-agent/pkg/util"
+	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
+)
+
+func TestImportImage(t *testing.T) {
+	mockRunner := &utiltest.MockRunner{}
+	s := snap.NewSnap("testdata", "testdata", mockRunner.Run)
+
+	err := s.ImportImage(context.Background(), []byte(`IMAGEDATA`))
+	if err != nil {
+		t.Fatalf("Expected no error but got %q instead", err)
+	}
+
+	// hex of SHA256("IMAGEDATA")
+	expectedFilename := "testdata/image-494d41474544415441e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.tar"
+
+	expectedCmd := []string{fmt.Sprintf("testdata/microk8s-ctr.wrapper image import %s", expectedFilename)}
+	if cmd := mockRunner.CalledWithCommand; !reflect.DeepEqual(cmd, expectedCmd) {
+		t.Fatalf("Expected command %q but received %q instead", expectedCmd, cmd)
+	}
+
+	if util.FileExists(expectedFilename) {
+		t.Fatalf("Expected file %q to not exist after image import, but it was not", expectedFilename)
+	}
+}


### PR DESCRIPTION
### Summary

Introduce `POST v2/image/import` API, which imports OCI images directly into the containerd daemon.

### Implementation notes

OCI image tar file is passed in the request body directly, and the callback token is passed in via a header. This is different from the other endpoints but gives the following two advantages:
   - We do not have to read the request body at all if the callback token is wrong, which saves bandwidth and makes requests faster.
   - The request body is an `io.Reader`, which can be passed as stdin all the way down to the `microk8s.ctr image import -` command.

I have decided to not silence any errors when importing the image, I figure that this is better left to the discretion of the client using the API.

### Testing

All changes are covered by unit tests. Also tested with a live MicroK8s instance, and added notes in the `README.md` to describe this process with local and remote MicroK8s instances.

### Example

```
# export alpine.tar image
$ microk8s.ctr content fetch --all-platforms docker.io/library/alpine:latest
$ microk8s.ctr image export - docker.io/library/alpine:latest > alpine.tar

# import
$ curl https://127.0.0.1:25000/cluster/api/v2.0/image/import -XPOST -H 'x-microk8s-callback-token: token' -T alpine.tar
```
