### PR TITLE
wip: Improve handling of joining multiple nodes at once

### DIFF
--- a/pkg/api/v2/api.go
+++ b/pkg/api/v2/api.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"net"
+	"sync"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 )
@@ -17,4 +18,10 @@ type API struct {
 
 	// LookupIP is net.LookupIP.
 	LookupIP func(string) ([]net.IP, error)
+
+	// dqliteMu protects changes involving the dqlite service.
+	dqliteMu sync.Mutex
+
+	// calicoMu protects changes involving the calico CNI.
+	calicoMu sync.Mutex
 }

--- a/pkg/snap/snap_token_test.go
+++ b/pkg/snap/snap_token_test.go
@@ -93,6 +93,19 @@ func TestCertificateRequestTokens(t *testing.T) {
 	if !s.ConsumeCertificateRequestToken("my-token") {
 		t.Fatal("Expected my-token to be a valid certificate request token, but it is not")
 	}
+
+	t.Run("Multiple", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			if err := s.AddCertificateRequestToken("my-token"); err != nil {
+				t.Fatalf("Failed to add certificate request token: %s", err)
+			}
+		}
+		for i := 0; i < 100; i++ {
+			if !s.ConsumeCertificateRequestToken("my-token") {
+				t.Fatal("Expected my-token to be a valid re-usable certificate request token, but it is not")
+			}
+		}
+	})
 }
 
 func TestCallbackTokens(t *testing.T) {


### PR DESCRIPTION
### Summary

Improve stability of cluster-agent when joining multiple nodes at once in the cluster

### Changes

- All cluster, callback and certificate token code is protected by a mutex. This prevents issues from dirty reads and blind writes, which could cause tokens to become invalid.
- When consuming tokens, only remove the first instance of the token in the tokens file.

### Testing

- Covered by existing unit tests
- Added test case for tokens that may exist multiple times in the tokens file.