### PR TITLE
Retry ApplyCNI a few times

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/canonical/microk8s-cluster-agent/pkg/server"
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
-	"github.com/canonical/microk8s-cluster-agent/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +31,11 @@ var rootCmd = &cobra.Command{
 lifecycle of a MicroK8s cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		s := snap.NewSnap(os.Getenv("SNAP"), os.Getenv("SNAP_DATA"), util.RunCommand)
+		s := snap.NewSnap(
+			os.Getenv("SNAP"),
+			os.Getenv("SNAP_DATA"),
+			snap.WithRetryApplyCNI(20, 3*time.Second),
+		)
 		apiv1 := &v1.API{
 			Snap:     s,
 			LookupIP: net.LookupIP,

--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -153,8 +154,7 @@ func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, er
 
 	a.calicoMu.Lock()
 	if err := snaputil.MaybePatchCalicoAutoDetectionMethod(ctx, a.Snap, remoteIP, true); err != nil {
-		a.calicoMu.Unlock()
-		return nil, http.StatusInternalServerError, fmt.Errorf("failed to update cni configuration: %w", err)
+		log.Printf("WARNING: failed to update cni configuration: %q", err)
 	}
 	a.calicoMu.Unlock()
 

--- a/pkg/snap/options.go
+++ b/pkg/snap/options.go
@@ -5,6 +5,16 @@ import (
 	"time"
 )
 
+// WithRetryApplyCNI configures how many times the ApplyCNI operation is retries before giving up.
+func WithRetryApplyCNI(times int, backoff time.Duration) func(s *snap) {
+	return func(s *snap) {
+		s.applyCNIRetries = times
+		if s.applyCNIRetries <= 0 {
+			s.applyCNIRetries = 1
+		}
+		s.applyCNIBackoff = backoff
+	}
+}
 
 // WithCommandRunner configures how shell commands are executed.
 func WithCommandRunner(f func(context.Context, ...string) error) func(s *snap) {

--- a/pkg/snap/options.go
+++ b/pkg/snap/options.go
@@ -1,0 +1,14 @@
+package snap
+
+import (
+	"context"
+	"time"
+)
+
+
+// WithCommandRunner configures how shell commands are executed.
+func WithCommandRunner(f func(context.Context, ...string) error) func(s *snap) {
+	return func(s *snap) {
+		s.runCommand = f
+	}
+}

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -29,13 +29,19 @@ type snap struct {
 }
 
 // NewSnap creates a new interface with the MicroK8s snap.
-// NewSnap accepts the $SNAP and $SNAP_DATA directories, as well as a function that executes shell commands.
-func NewSnap(snapDir, snapDataDir string, runCommand func(context.Context, ...string) error) Snap {
-	return &snap{
+// NewSnap accepts the $SNAP and $SNAP_DATA directories, and a number of options.
+func NewSnap(snapDir, snapDataDir string, options ...func(s *snap)) Snap {
+	s := &snap{
 		snapDir:     snapDir,
 		snapDataDir: snapDataDir,
-		runCommand:  runCommand,
+		runCommand:  util.RunCommand,
 	}
+
+	for _, opt := range options {
+		opt(s)
+	}
+	return s
+
 }
 
 func (s *snap) snapPath(parts ...string) string {

--- a/pkg/snap/snap_files_test.go
+++ b/pkg/snap/snap_files_test.go
@@ -41,7 +41,7 @@ func TestFiles(t *testing.T) {
 		defer os.RemoveAll(filepath.Dir(file))
 	}
 
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 
 	for _, tc := range []struct {
 		name     string

--- a/pkg/snap/snap_images_test.go
+++ b/pkg/snap/snap_images_test.go
@@ -31,7 +31,7 @@ func TestImportImage(t *testing.T) {
 		os.Remove("testdata/arguments")
 	}()
 	mockRunner := &utiltest.MockRunner{}
-	s := snap.NewSnap("testdata", "testdata", mockRunner.Run)
+	s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(mockRunner.Run))
 
 	err := s.ImportImage(context.Background(), bytes.NewBufferString("IMAGEDATA"))
 	if err != nil {

--- a/pkg/snap/snap_lock_test.go
+++ b/pkg/snap/snap_lock_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLock(t *testing.T) {
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 	if err := os.MkdirAll("testdata/var/lock", 0755); err != nil {
 		t.Fatalf("Failed to create directory: %s", err)
 	}

--- a/pkg/snap/snap_service_test.go
+++ b/pkg/snap/snap_service_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestServiceRestart(t *testing.T) {
 	mockRunner := &utiltest.MockRunner{}
-	s := snap.NewSnap("testdata", "testdata", mockRunner.Run)
+	s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(mockRunner.Run))
 
 	t.Run("NoKubelite", func(t *testing.T) {
 		for _, tc := range []struct {

--- a/pkg/snap/snap_sign_test.go
+++ b/pkg/snap/snap_sign_test.go
@@ -90,7 +90,7 @@ func TestSignCert(t *testing.T) {
 		t.Fatalf("Failed to write test certificate key: %s", err)
 	}
 
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 
 	certificate, err := s.SignCertificate(context.Background(), []byte(csrPEM))
 	if err != nil {

--- a/pkg/snap/snap_token_test.go
+++ b/pkg/snap/snap_token_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestClusterTokens(t *testing.T) {
 	os.RemoveAll("testdata/credentials")
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 	t.Run("MissingTokensFile", func(t *testing.T) {
 		if s.ConsumeClusterToken("token1") {
 			t.Fatal("Expected token1 to not be valid, but it is")
@@ -79,7 +79,7 @@ func TestCertificateRequestTokens(t *testing.T) {
 		t.Fatalf("Failed to create test directory: %s", err)
 	}
 	defer os.RemoveAll("testdata/credentials")
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 	if err := s.AddCertificateRequestToken("my-token"); err != nil {
 		t.Fatalf("Failed to add certificate request token: %s", err)
 	}
@@ -113,7 +113,7 @@ func TestCallbackTokens(t *testing.T) {
 		t.Fatalf("Failed to create test directory: %s", err)
 	}
 	defer os.RemoveAll("testdata/credentials")
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 	if err := s.AddCallbackToken("ip:port", "my-token"); err != nil {
 		t.Fatalf("Failed to add certificate request token: %s", err)
 	}
@@ -131,7 +131,7 @@ func TestSelfCallbackToken(t *testing.T) {
 		t.Fatalf("Failed to create test directory: %s", err)
 	}
 	defer os.RemoveAll("testdata/credentials")
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 	token, err := s.GetOrCreateSelfCallbackToken()
 	if err != nil {
 		t.Fatalf("Failed to configure callback token: %q", err)
@@ -156,7 +156,7 @@ func TestKnownTokens(t *testing.T) {
 		t.Fatalf("Failed to create test directory: %s", err)
 	}
 	defer os.RemoveAll("testdata/credentials")
-	s := snap.NewSnap("testdata", "testdata", nil)
+	s := snap.NewSnap("testdata", "testdata")
 	if token, err := s.GetKnownToken("user"); token != "" || err == nil {
 		t.Fatalf("Expected an empty token and an error, but found token %s and error %s", token, err)
 	}
@@ -235,7 +235,7 @@ func TestStrictGroup(t *testing.T) {
 		if err := os.WriteFile("testdata/meta/snapcraft.yaml", []byte(fmt.Sprintf("confinement: %s", tc.confinement)), 0660); err != nil {
 			t.Fatalf("Failed to create test file: %s", err)
 		}
-		group := snap.NewSnap("testdata", "testdata", nil).GetGroupName()
+		group := snap.NewSnap("testdata", "testdata").GetGroupName()
 		if tc.group != group {
 			t.Fatalf("Expected group to be %q but it was %q instead", tc.group, group)
 		}

--- a/pkg/snap/snap_upgrade_test.go
+++ b/pkg/snap/snap_upgrade_test.go
@@ -31,7 +31,7 @@ func TestRunUpgrade(t *testing.T) {
 	defer os.RemoveAll("testdata/upgrade-scripts")
 
 	runner := &utiltest.MockRunner{}
-	s := snap.NewSnap("testdata", "testdata", runner.Run)
+	s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(runner.Run))
 
 	t.Run("Invalid", func(t *testing.T) {
 		for _, tc := range []struct {
@@ -58,7 +58,7 @@ func TestRunUpgrade(t *testing.T) {
 			t.Run(phase, func(t *testing.T) {
 
 				runner := &utiltest.MockRunner{}
-				s := snap.NewSnap("testdata", "testdata", runner.Run)
+				s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(runner.Run))
 
 				err := s.RunUpgrade(context.Background(), "001-custom-upgrade", phase)
 				if err != nil {


### PR DESCRIPTION
## Summary

Sometimes, when joining multiple nodes simultaneously in an initially single-node cluster, applying the CNI may fail due to coinciding with a dqlite service restart.

Add configuration to retry the kubectl apply call a few times. Also, convert this situation to a non-fatal error.