### PR TITLE
Add API server proxy command

### DIFF
--- a/cmd/apiserver-proxy.go
+++ b/cmd/apiserver-proxy.go
@@ -19,7 +19,9 @@ var (
 	apiServerProxyRefreshInterval time.Duration
 
 	apiServerProxyCmd = &cobra.Command{
-		Use: "apiserver-proxy",
+		Use:   "apiserver-proxy",
+		Short: "MicroK8s apiserver proxy",
+		Long:  `Local API server proxy for MicroK8s worker nodes. Forwards all requests to the active cluster API servers.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p := &proxy.APIServerProxy{
 				ConfigFile:     apiServerProxyConfig,
@@ -40,7 +42,7 @@ var (
 
 func init() {
 	apiServerProxyCmd.Flags().StringVar(&apiServerProxyConfig, "config", filepath.Join(os.Getenv("SNAP_DATA"), "args", "apiserver-proxy-config"), "path to apiserver proxy config file")
-	apiServerProxyCmd.Flags().StringVar(&apiServerProxyKubeconfig, "kubeconfig", filepath.Join(os.Getenv("SNAP_DATA"), "credentials", "kubelet.config"), "path to kubeconfig file to use for updating control plane nodes")
+	apiServerProxyCmd.Flags().StringVar(&apiServerProxyKubeconfig, "kubeconfig", filepath.Join(os.Getenv("SNAP_DATA"), "credentials", "kubelet.config"), "path to kubeconfig file to use for updating list of known control plane nodes")
 	apiServerProxyCmd.Flags().DurationVar(&apiServerProxyRefreshInterval, "refresh-interval", 30*time.Second, "refresh interval")
 
 	rootCmd.AddCommand(apiServerProxyCmd)

--- a/cmd/apiserver-proxy.go
+++ b/cmd/apiserver-proxy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -23,6 +24,10 @@ var (
 		Short: "MicroK8s apiserver proxy",
 		Long:  `Local API server proxy for MicroK8s worker nodes. Forwards all requests to the active cluster API servers.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if apiServerProxyRefreshInterval < 10*time.Second {
+				log.Printf("Refresh interval %v is less than minimum of 10s. Using the minimum 10s instead.\n", apiServerProxyRefreshInterval)
+				apiServerProxyRefreshInterval = 10 * time.Second
+			}
 			p := &proxy.APIServerProxy{
 				ConfigFile:     apiServerProxyConfig,
 				KubeconfigFile: apiServerProxyKubeconfig,

--- a/cmd/apiserver-proxy.go
+++ b/cmd/apiserver-proxy.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/canonical/microk8s-cluster-agent/pkg/proxy"
+	"github.com/spf13/cobra"
+)
+
+var (
+	apiServerProxyConfig          string
+	apiServerProxyKubeconfig      string
+	apiServerProxyRefreshInterval time.Duration
+
+	apiServerProxyCmd = &cobra.Command{
+		Use: "apiserver-proxy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p := &proxy.APIServerProxy{
+				ConfigFile:     apiServerProxyConfig,
+				KubeconfigFile: apiServerProxyKubeconfig,
+				RefreshCh:      time.NewTicker(apiServerProxyRefreshInterval).C,
+			}
+
+			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer cancel()
+
+			if err := p.Run(ctx); err != nil {
+				return fmt.Errorf("proxy failed: %w", err)
+			}
+			return nil
+		},
+	}
+)
+
+func init() {
+	apiServerProxyCmd.Flags().StringVar(&apiServerProxyConfig, "config", filepath.Join(os.Getenv("SNAP_DATA"), "args", "apiserver-proxy-config"), "path to apiserver proxy config file")
+	apiServerProxyCmd.Flags().StringVar(&apiServerProxyKubeconfig, "kubeconfig", filepath.Join(os.Getenv("SNAP_DATA"), "credentials", "kubelet.config"), "path to kubeconfig file to use for updating control plane nodes")
+	apiServerProxyCmd.Flags().DurationVar(&apiServerProxyRefreshInterval, "refresh-interval", 30*time.Second, "refresh interval")
+
+	rootCmd.AddCommand(apiServerProxyCmd)
+}

--- a/cmd/cluster-agent.go
+++ b/cmd/cluster-agent.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	v1 "github.com/canonical/microk8s-cluster-agent/pkg/api/v1"
+	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
+	"github.com/canonical/microk8s-cluster-agent/pkg/server"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
+	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bind          string
+	keyfile       string
+	certfile      string
+	timeout       int
+	enableMetrics bool
+)
+
+// clusterAgentCmd represents the base command when called without any subcommands
+var clusterAgentCmd = &cobra.Command{
+	Use:   "cluster-agent",
+	Short: "MicroK8s cluster agent",
+	Long: `The MicroK8s cluster agent is an API server that orchestrates the
+lifecycle of a MicroK8s cluster.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		s := snap.NewSnap(
+			os.Getenv("SNAP"),
+			os.Getenv("SNAP_DATA"),
+			snap.WithRetryApplyCNI(20, 3*time.Second),
+		)
+		apiv1 := &v1.API{
+			Snap:     s,
+			LookupIP: net.LookupIP,
+		}
+		apiv2 := &v2.API{
+			Snap:                    s,
+			LookupIP:                net.LookupIP,
+			ListControlPlaneNodeIPs: snaputil.ListControlPlaneNodeIPs,
+		}
+		srv := server.NewServer(time.Duration(timeout)*time.Second, enableMetrics, apiv1, apiv2)
+		log.Printf("Starting cluster agent on https://%s\n", bind)
+		if err := http.ListenAndServeTLS(bind, certfile, keyfile, srv); err != nil {
+			log.Fatalf("Failed to listen: %s", err)
+		}
+	},
+}
+
+func init() {
+	clusterAgentCmd.Flags().StringVar(&bind, "bind", "0.0.0.0:25000", "Listen address for server")
+	clusterAgentCmd.Flags().StringVar(&keyfile, "keyfile", "", "Private key for serving TLS")
+	clusterAgentCmd.Flags().StringVar(&certfile, "certfile", "", "Certificate for serving TLS")
+	clusterAgentCmd.Flags().IntVar(&timeout, "timeout", 240, "Default request timeout (in seconds)")
+	clusterAgentCmd.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics endpoint")
+
+	rootCmd.AddCommand(clusterAgentCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,56 +1,14 @@
 package cmd
 
 import (
-	"log"
-	"net"
-	"net/http"
 	"os"
-	"time"
 
-	v1 "github.com/canonical/microk8s-cluster-agent/pkg/api/v1"
-	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
-	"github.com/canonical/microk8s-cluster-agent/pkg/server"
-	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
-	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
 	"github.com/spf13/cobra"
-)
-
-var (
-	bind          string
-	keyfile       string
-	certfile      string
-	timeout       int
-	enableMetrics bool
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "cluster-agent",
-	Short: "MicroK8s cluster agent",
-	Long: `The MicroK8s cluster agent is an API server that orchestrates the
-lifecycle of a MicroK8s cluster.`,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		s := snap.NewSnap(
-			os.Getenv("SNAP"),
-			os.Getenv("SNAP_DATA"),
-			snap.WithRetryApplyCNI(20, 3*time.Second),
-		)
-		apiv1 := &v1.API{
-			Snap:     s,
-			LookupIP: net.LookupIP,
-		}
-		apiv2 := &v2.API{
-			Snap:                    s,
-			LookupIP:                net.LookupIP,
-			ListControlPlaneNodeIPs: snaputil.ListControlPlaneNodeIPs,
-		}
-		srv := server.NewServer(time.Duration(timeout)*time.Second, enableMetrics, apiv1, apiv2)
-		log.Printf("Starting cluster agent on https://%s\n", bind)
-		if err := http.ListenAndServeTLS(bind, certfile, keyfile, srv); err != nil {
-			log.Fatalf("Failed to listen: %s", err)
-		}
-	},
+	Short: "MicroK8s",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -60,12 +18,4 @@ func Execute() {
 	if err != nil {
 		os.Exit(1)
 	}
-}
-
-func init() {
-	rootCmd.Flags().StringVar(&bind, "bind", "0.0.0.0:25000", "Listen address for server")
-	rootCmd.Flags().StringVar(&keyfile, "keyfile", "", "Private key for serving TLS")
-	rootCmd.Flags().StringVar(&certfile, "certfile", "", "Certificate for serving TLS")
-	rootCmd.Flags().IntVar(&timeout, "timeout", 240, "Default request timeout (in seconds)")
-	rootCmd.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics endpoint")
 }

--- a/pkg/proxy/apiserver.go
+++ b/pkg/proxy/apiserver.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"sort"
+	"time"
+)
+
+type apiServerProxyConfig struct {
+	Listen    string   `json:"listen"`
+	Endpoints []string `json:"endpoints"`
+}
+
+type APIServerProxy struct {
+	ConfigFile     string
+	KubeconfigFile string
+	RefreshCh      <-chan time.Time
+}
+
+func (p *APIServerProxy) Run(ctx context.Context) error {
+	b, err := os.ReadFile(p.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+	cfg := &apiServerProxyConfig{}
+	if err := json.Unmarshal(b, cfg); err != nil {
+		return fmt.Errorf("failed to parse config file: %w", err)
+	}
+	if len(cfg.Endpoints) == 0 {
+		return fmt.Errorf("fatal error: no known control plane nodes are left")
+	}
+	sort.Strings(cfg.Endpoints)
+	if cfg.Listen == "" {
+		cfg.Listen = "127.0.0.1:16443"
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		proxyCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+		nextUpdate:
+			for {
+				select {
+				case <-proxyCtx.Done():
+					return
+				case <-ctx.Done():
+					return
+				case <-p.RefreshCh:
+				}
+
+				endpoints, err := getKubernetesEndpoints(proxyCtx, p.KubeconfigFile)
+				switch {
+				case err != nil:
+					log.Println(fmt.Errorf("failed to retrieve kubernetes endpoints: %w", err))
+					continue nextUpdate
+				case len(endpoints) == 0:
+					log.Println("warning: empty list of endpoints, skipping update")
+					continue nextUpdate
+				case len(endpoints) == len(cfg.Endpoints) && reflect.DeepEqual(endpoints, cfg.Endpoints):
+					continue nextUpdate
+				}
+				log.Println("updating endpoints")
+
+				cfg.Endpoints = endpoints
+				// first update the configuration file to preserve changes
+				if err := updateConfigFile(p.ConfigFile, cfg); err != nil {
+					log.Println(fmt.Errorf("warning: failed to update configuration file: %w", err))
+				}
+
+				// cancel context in order to restart the proxy
+				cancel()
+				return
+			}
+		}()
+
+		if err := startProxy(proxyCtx, cfg.Listen, cfg.Endpoints); err != nil {
+			log.Println(fmt.Errorf("apiserver proxy failed: %w", err))
+			cancel()
+		}
+	}
+}

--- a/pkg/proxy/apiserver.go
+++ b/pkg/proxy/apiserver.go
@@ -11,11 +11,6 @@ import (
 	"time"
 )
 
-type apiServerProxyConfig struct {
-	Listen    string   `json:"listen"`
-	Endpoints []string `json:"endpoints"`
-}
-
 // APIServerProxy is a TCP proxy that forwards requests to the API Servers of the cluster.
 type APIServerProxy struct {
 	// ConfigFile is the path to the config file of the apiserver proxy.

--- a/pkg/proxy/apiserver.go
+++ b/pkg/proxy/apiserver.go
@@ -16,12 +16,19 @@ type apiServerProxyConfig struct {
 	Endpoints []string `json:"endpoints"`
 }
 
+// APIServerProxy is a TCP proxy that forwards requests to the API Servers of the cluster.
 type APIServerProxy struct {
-	ConfigFile     string
+	// ConfigFile is the path to the config file of the apiserver proxy.
+	// ConfigFile contains configuration in JSON format.
+	ConfigFile string
+	// KubeconfigFile is the path to the kubeconfig file to use for updating the list of known apiservers.
+	// The known apiservers are retrieved from `kubectl get endpoints kubernetes`.
 	KubeconfigFile string
-	RefreshCh      <-chan time.Time
+	// RefreshCh is used to check for updates in the list of control plane nodes in the cluster.
+	RefreshCh <-chan time.Time
 }
 
+// Run starts the proxy.
 func (p *APIServerProxy) Run(ctx context.Context) error {
 	b, err := os.ReadFile(p.ConfigFile)
 	if err != nil {

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -1,0 +1,6 @@
+package proxy
+
+type apiServerProxyConfig struct {
+	Listen    string   `json:"listen"`
+	Endpoints []string `json:"endpoints"`
+}

--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -5,24 +5,15 @@ import (
 	"fmt"
 	"sort"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func getKubernetesEndpoints(ctx context.Context, kubeconfigFile string) ([]string, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read load kubeconfig: %w", err)
-	}
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
-	}
-
-	endpoint, err := clientset.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve endpoints for kubernetes service: %w", err)
+func parseAddresses(endpoint *v1.Endpoints) []string {
+	if endpoint == nil {
+		return nil
 	}
 	addresses := make([]string, 0, len(endpoint.Subsets))
 	for _, subset := range endpoint.Subsets {
@@ -40,6 +31,22 @@ func getKubernetesEndpoints(ctx context.Context, kubeconfigFile string) ([]strin
 	}
 
 	sort.Strings(addresses)
+	return addresses
+}
 
-	return addresses, nil
+func getKubernetesEndpoints(ctx context.Context, kubeconfigFile string) ([]string, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read load kubeconfig: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
+	}
+
+	endpoint, err := clientset.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve endpoints for kubernetes service: %w", err)
+	}
+	return parseAddresses(endpoint), nil
 }

--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func getKubernetesEndpoints(ctx context.Context, kubeconfigFile string) ([]string, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read load kubeconfig: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
+	}
+
+	endpoint, err := clientset.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve endpoints for kubernetes service: %w", err)
+	}
+	addresses := make([]string, 0, len(endpoint.Subsets))
+	for _, subset := range endpoint.Subsets {
+		portNumber := 16443
+		for _, port := range subset.Ports {
+			if port.Name == "https" {
+				portNumber = int(port.Port)
+				break
+			}
+		}
+
+		for _, addr := range subset.Addresses {
+			addresses = append(addresses, fmt.Sprintf("%s:%d", addr.IP, portNumber))
+		}
+	}
+
+	sort.Strings(addresses)
+
+	return addresses, nil
+}

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestParseAddresses(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		endpoints *v1.Endpoints
+		addresses []string
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name: "one",
+			endpoints: &v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}}},
+				},
+			},
+			addresses: []string{"1.1.1.1:16443"},
+		},
+		{
+			name: "two",
+			endpoints: &v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}}},
+				},
+			},
+			addresses: []string{"1.1.1.1:16443", "2.2.2.2:16443"},
+		},
+		{
+			name: "multiple-subsets",
+			endpoints: &v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}}},
+					{Addresses: []v1.EndpointAddress{{IP: "3.3.3.3"}}},
+				},
+			},
+			addresses: []string{"1.1.1.1:16443", "2.2.2.2:16443", "3.3.3.3:16443"},
+		},
+		{
+			name: "override-port",
+			endpoints: &v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}}},
+					{Addresses: []v1.EndpointAddress{{IP: "3.3.3.3"}}, Ports: []v1.EndpointPort{{Port: int32(10000), Name: "https"}}},
+				},
+			},
+			addresses: []string{"1.1.1.1:16443", "2.2.2.2:16443", "3.3.3.3:10000"},
+		},
+		{
+			name: "sort",
+			endpoints: &v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{Addresses: []v1.EndpointAddress{{IP: "3.3.3.3"}, {IP: "1.1.1.1"}}},
+					{Addresses: []v1.EndpointAddress{{IP: "2.2.2.2"}}, Ports: []v1.EndpointPort{{Port: int32(10000), Name: "https"}}},
+				},
+			},
+			addresses: []string{"1.1.1.1:16443", "2.2.2.2:10000", "3.3.3.3:16443"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if parsed := parseAddresses(tc.endpoints); !reflect.DeepEqual(parsed, tc.addresses) {
+				t.Fatalf("expected addresses to be %v but they were %v instead", tc.addresses, parsed)
+			}
+		})
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -42,7 +42,11 @@ func startProxy(ctx context.Context, listenURL string, endpointURLs []string) er
 	}
 
 	log.Println("Starting proxy at", listenURL)
-	go p.Run()
+	go func() {
+		if err := p.Run(); err != nil {
+			log.Printf("proxy failed: %v\n", err)
+		}
+	}()
 
 	<-ctx.Done()
 	p.Stop()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,51 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+func startProxy(ctx context.Context, listenURL string, endpointURLs []string) error {
+	if len(endpointURLs) == 0 {
+		return fmt.Errorf("empty list of endpoints")
+	}
+	srvs := make([]*net.SRV, len(endpointURLs))
+	for i, endpoint := range endpointURLs {
+		if u, err := url.Parse(endpoint); err == nil && u.Host != "" {
+			endpoint = u.Host
+		}
+		host, port, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to parse endpoint %q: %w", endpoint, err)
+		}
+		portNumber, err := strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			return fmt.Errorf("failed to parse port %q: %w", port, err)
+		}
+		srvs[i] = &net.SRV{Target: host, Port: uint16(portNumber)}
+	}
+
+	l, err := net.Listen("tcp", listenURL)
+	if err != nil {
+		return fmt.Errorf("failed to start listener: %w", err)
+	}
+
+	p := TCPProxy{
+		Listener:        l,
+		Endpoints:       srvs,
+		MonitorInterval: time.Minute,
+	}
+
+	log.Println("Starting proxy at", listenURL)
+	go p.Run()
+
+	<-ctx.Done()
+	p.Stop()
+
+	return nil
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -35,7 +35,7 @@ func startProxy(ctx context.Context, listenURL string, endpointURLs []string) er
 		return fmt.Errorf("failed to start listener: %w", err)
 	}
 
-	p := TCPProxy{
+	p := tcpproxy{
 		Listener:        l,
 		Endpoints:       srvs,
 		MonitorInterval: time.Minute,

--- a/pkg/proxy/userspace.go
+++ b/pkg/proxy/userspace.go
@@ -60,7 +60,7 @@ func (r *remote) isActive() bool {
 	return !r.inactive
 }
 
-type TCPProxy struct {
+type tcpproxy struct {
 	Listener        net.Listener
 	Endpoints       []*net.SRV
 	MonitorInterval time.Duration
@@ -72,7 +72,7 @@ type TCPProxy struct {
 	pickCount int // for round robin
 }
 
-func (tp *TCPProxy) Run() error {
+func (tp *tcpproxy) Run() error {
 	tp.donec = make(chan struct{})
 	if tp.MonitorInterval == 0 {
 		tp.MonitorInterval = 5 * time.Minute
@@ -99,7 +99,7 @@ func (tp *TCPProxy) Run() error {
 	}
 }
 
-func (tp *TCPProxy) pick() *remote {
+func (tp *tcpproxy) pick() *remote {
 	var weighted []*remote
 	var unweighted []*remote
 
@@ -156,7 +156,7 @@ func (tp *TCPProxy) pick() *remote {
 	return nil
 }
 
-func (tp *TCPProxy) serve(in net.Conn) {
+func (tp *tcpproxy) serve(in net.Conn) {
 	var (
 		err error
 		out net.Conn
@@ -194,7 +194,7 @@ func (tp *TCPProxy) serve(in net.Conn) {
 	in.Close()
 }
 
-func (tp *TCPProxy) runMonitor() {
+func (tp *tcpproxy) runMonitor() {
 	for {
 		select {
 		case <-time.After(tp.MonitorInterval):
@@ -218,7 +218,7 @@ func (tp *TCPProxy) runMonitor() {
 	}
 }
 
-func (tp *TCPProxy) Stop() {
+func (tp *tcpproxy) Stop() {
 	// graceful shutdown?
 	// shutdown current connections?
 	tp.Listener.Close()

--- a/pkg/proxy/userspace.go
+++ b/pkg/proxy/userspace.go
@@ -1,0 +1,226 @@
+// This code is based on the tcpproxy implementation found in
+// https://github.com/etcd-io/etcd/blob/v3.5.4/server/proxy/tcpproxy/userspace.go
+//
+// Original copyright notice follows:
+
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+)
+
+type remote struct {
+	mu       sync.Mutex
+	srv      *net.SRV
+	addr     string
+	inactive bool
+}
+
+func (r *remote) inactivate() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inactive = true
+}
+
+func (r *remote) tryReactivate() error {
+	conn, err := net.Dial("tcp", r.addr)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inactive = false
+	return nil
+}
+
+func (r *remote) isActive() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return !r.inactive
+}
+
+type TCPProxy struct {
+	Listener        net.Listener
+	Endpoints       []*net.SRV
+	MonitorInterval time.Duration
+
+	donec chan struct{}
+
+	mu        sync.Mutex // guards the following fields
+	remotes   []*remote
+	pickCount int // for round robin
+}
+
+func (tp *TCPProxy) Run() error {
+	tp.donec = make(chan struct{})
+	if tp.MonitorInterval == 0 {
+		tp.MonitorInterval = 5 * time.Minute
+	}
+	for _, srv := range tp.Endpoints {
+		addr := fmt.Sprintf("%s:%d", srv.Target, srv.Port)
+		tp.remotes = append(tp.remotes, &remote{srv: srv, addr: addr})
+	}
+
+	eps := []string{}
+	for _, ep := range tp.Endpoints {
+		eps = append(eps, fmt.Sprintf("%s:%d", ep.Target, ep.Port))
+	}
+	log.Printf("ready to proxy client requests to %v\n", eps)
+
+	go tp.runMonitor()
+	for {
+		in, err := tp.Listener.Accept()
+		if err != nil {
+			return err
+		}
+
+		go tp.serve(in)
+	}
+}
+
+func (tp *TCPProxy) pick() *remote {
+	var weighted []*remote
+	var unweighted []*remote
+
+	bestPr := uint16(65535)
+	w := 0
+	// find best priority class
+	for _, r := range tp.remotes {
+		switch {
+		case !r.isActive():
+		case r.srv.Priority < bestPr:
+			bestPr = r.srv.Priority
+			w = 0
+			weighted = nil
+			unweighted = nil
+			fallthrough
+		case r.srv.Priority == bestPr:
+			if r.srv.Weight > 0 {
+				weighted = append(weighted, r)
+				w += int(r.srv.Weight)
+			} else {
+				unweighted = append(unweighted, r)
+			}
+		}
+	}
+	if weighted != nil {
+		if len(unweighted) > 0 && rand.Intn(100) == 1 {
+			// In the presence of records containing weights greater
+			// than 0, records with weight 0 should have a very small
+			// chance of being selected.
+			r := unweighted[tp.pickCount%len(unweighted)]
+			tp.pickCount++
+			return r
+		}
+		// choose a uniform random number between 0 and the sum computed
+		// (inclusive), and select the RR whose running sum value is the
+		// first in the selected order
+		choose := rand.Intn(w)
+		for i := 0; i < len(weighted); i++ {
+			choose -= int(weighted[i].srv.Weight)
+			if choose <= 0 {
+				return weighted[i]
+			}
+		}
+	}
+	if unweighted != nil {
+		for i := 0; i < len(tp.remotes); i++ {
+			picked := tp.remotes[tp.pickCount%len(tp.remotes)]
+			tp.pickCount++
+			if picked.isActive() {
+				return picked
+			}
+		}
+	}
+	return nil
+}
+
+func (tp *TCPProxy) serve(in net.Conn) {
+	var (
+		err error
+		out net.Conn
+	)
+
+	for {
+		tp.mu.Lock()
+		remote := tp.pick()
+		tp.mu.Unlock()
+		if remote == nil {
+			break
+		}
+		// TODO: add timeout
+		out, err = net.Dial("tcp", remote.addr)
+		if err == nil {
+			break
+		}
+		remote.inactivate()
+		log.Printf("deactivated endpoint %v for interval %v, error was %q", remote.addr, tp.MonitorInterval, err)
+	}
+
+	if out == nil {
+		in.Close()
+		return
+	}
+
+	go func() {
+		io.Copy(in, out)
+		in.Close()
+		out.Close()
+	}()
+
+	io.Copy(out, in)
+	out.Close()
+	in.Close()
+}
+
+func (tp *TCPProxy) runMonitor() {
+	for {
+		select {
+		case <-time.After(tp.MonitorInterval):
+			tp.mu.Lock()
+			for _, rem := range tp.remotes {
+				if rem.isActive() {
+					continue
+				}
+				go func(r *remote) {
+					if err := r.tryReactivate(); err != nil {
+						log.Printf("failed to activate endpoint %v (stay inactive for another interval %v)\n", r.addr, tp.MonitorInterval)
+					} else {
+						log.Printf("activated endpoint %v\n", r.addr)
+					}
+				}(rem)
+			}
+			tp.mu.Unlock()
+		case <-tp.donec:
+			return
+		}
+	}
+}
+
+func (tp *TCPProxy) Stop() {
+	// graceful shutdown?
+	// shutdown current connections?
+	tp.Listener.Close()
+	close(tp.donec)
+}

--- a/pkg/proxy/util.go
+++ b/pkg/proxy/util.go
@@ -1,0 +1,19 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func updateConfigFile(configFile string, config *apiServerProxyConfig) error {
+	b, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal configuration: %w", err)
+	}
+
+	if err := os.WriteFile(configFile, b, 0644); err != nil {
+		return fmt.Errorf("failed to update configuration file %q: %w", configFile, err)
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary

Add API server proxy command, meant for worker nodes.

### Details

The apiserver proxy can be run as follows:

```bash
./cluster-agent apiserver-proxy --config proxy-config.json --kubeconfig kubelet.config --refresh-interval 1m
```

The config file looks like this:

```json
{"listen":"127.0.0.1:16443", "endpoints":["10.0.0.1:16443", "10.0.0.2:16443"]}
```

The API server proxy will automatically query the Kubernetes cluster for the updated list of apiserver endpoints as registered by the components themselves (through the output of `kubectl get endpoints kubernetes`), and update the proxy as needed.

