### PR TITLE
util: Identify when service arguments are updated

### DIFF
--- a/pkg/api/v1/configure.go
+++ b/pkg/api/v1/configure.go
@@ -47,7 +47,7 @@ func (a *API) Configure(ctx context.Context, req ConfigureRequest) error {
 		return fmt.Errorf("invalid token")
 	}
 	for _, service := range req.ConfigureServices {
-		if err := snaputil.UpdateServiceArguments(a.Snap, service.Name, service.UpdateArguments, service.RemoveArguments); err != nil {
+		if _, err := snaputil.UpdateServiceArguments(a.Snap, service.Name, service.UpdateArguments, service.RemoveArguments); err != nil {
 			return fmt.Errorf("failed to update arguments of service %q: %w", service.Name, err)
 		}
 		if service.Restart {

--- a/pkg/snap/util/services.go
+++ b/pkg/snap/util/services.go
@@ -34,7 +34,8 @@ func GetServiceArgument(s snap.Snap, serviceName string, argument string) string
 // UpdateServiceArguments is a no-op if updateList and delete are empty.
 // updateList is a map of key-value pairs. It will replace the argument with the new value (or just append).
 // delete is a list of arguments to remove completely. The argument is removed if present.
-func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[string]string, delete []string) error {
+// Returns a boolean whether any of the arguments were changed, as well as any errors that may have occured.
+func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[string]string, delete []string) (bool, error) {
 	if updateList == nil {
 		updateList = []map[string]string{}
 	}
@@ -44,7 +45,7 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 
 	// If no updates are requested, exit early
 	if len(updateList) == 0 && len(delete) == 0 {
-		return nil
+		return false, nil
 	}
 
 	deleteMap := make(map[string]struct{}, len(delete))
@@ -61,9 +62,10 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 
 	arguments, err := s.ReadServiceArguments(serviceName)
 	if err != nil {
-		return fmt.Errorf("failed to read arguments of service %s: %w", serviceName, err)
+		return false, fmt.Errorf("failed to read arguments of service %s: %w", serviceName, err)
 	}
 
+	changed := false
 	existingArguments := make(map[string]struct{}, len(arguments))
 	newArguments := make([]string, 0, len(arguments))
 	for _, line := range strings.Split(arguments, "\n") {
@@ -72,13 +74,17 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 		if line == "" {
 			continue
 		}
-		key, _ := util.ParseArgumentLine(line)
+		key, oldValue := util.ParseArgumentLine(line)
 		existingArguments[key] = struct{}{}
 		if newValue, ok := updateMap[key]; ok {
 			// update argument with new value
 			newArguments = append(newArguments, fmt.Sprintf("%s=%s", key, newValue))
+			if oldValue != newValue {
+				changed = true
+			}
 		} else if _, ok := deleteMap[key]; ok {
 			// remove argument
+			changed = true
 			continue
 		} else {
 			// no change
@@ -88,12 +94,13 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 
 	for key, value := range updateMap {
 		if _, argExists := existingArguments[key]; !argExists {
+			changed = true
 			newArguments = append(newArguments, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
 
 	if err := s.WriteServiceArguments(serviceName, []byte(strings.Join(newArguments, "\n")+"\n")); err != nil {
-		return fmt.Errorf("failed to update arguments for service %s: %q", serviceName, err)
+		return false, fmt.Errorf("failed to update arguments for service %s: %q", serviceName, err)
 	}
-	return nil
+	return changed, nil
 }

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
 )
 
 // FileExists returns true if the specified path exists.
@@ -32,4 +33,23 @@ func ReadFile(path string) (string, error) {
 		return "", fmt.Errorf("failed to read %s: %w", path, err)
 	}
 	return string(b), nil
+}
+
+// ParseArgumentLine parses a command-line argument from a single line.
+// The returned key includes any dash prefixes.
+func ParseArgumentLine(line string) (key string, value string) {
+	line = strings.TrimSpace(line)
+
+	// parse "--argument value" and "--argument=value" variants
+	if parts := strings.Split(line, "="); len(parts) >= 2 {
+		key = parts[0]
+		value = parts[1]
+	} else if parts := strings.Split(line, " "); len(parts) >= 2 {
+		key = parts[0]
+		value = strings.Join(parts[1:], " ")
+	} else {
+		key = line
+	}
+
+	return
 }

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -40,3 +40,30 @@ func TestReadFile(t *testing.T) {
 	}
 	os.Remove("testdata/test-read-file")
 }
+
+func TestParseArgumentLine(t *testing.T) {
+	for _, tc := range []struct {
+		line, key, value string
+	}{
+		{line: "--key=value", key: "--key", value: "value"},
+		{line: "--key=value   ", key: "--key", value: "value"},
+		{line: "--key value", key: "--key", value: "value"},
+		{line: "--key value     ", key: "--key", value: "value"},
+		{line: "--key value value", key: "--key", value: "value value"},
+		{line: "--key=value value", key: "--key", value: "value value"},
+		{line: "--key", key: "--key", value: ""},
+		{line: "--key    ", key: "--key", value: ""},
+		{line: "--key=", key: "--key", value: ""},
+		{line: "--key=    ", key: "--key", value: ""},
+	} {
+		t.Run(tc.line, func(t *testing.T) {
+			key, value := util.ParseArgumentLine(tc.line)
+			if key != tc.key {
+				t.Fatalf("Expected key to be %q but it was %q instead", tc.key, key)
+			}
+			if value != tc.value {
+				t.Fatalf("Expected value to be %q but it was %q instead", tc.value, value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Extend `snaputil.UpdateServiceArguments()` to also return whether any service arguments were updated during the operation. This is useful for launch configurations to restart any services **iff** needed, to reduce needless control plane disruptions.

### Notes

This is split into a separate PR to simplify how the work is reviewed.

### Testing

Existing unit tests prevent regressions for known scenarios around argument parsing. Added new unit tests for the new parsing function and extended existing tests for the new functionality.