### PR TITLE
Add pre-init mode

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	initInputFile = ""
+	initInputFile string
+	initPreInit   bool
 
 	initCmd = &cobra.Command{
 		Use:    "init",
@@ -22,7 +23,7 @@ var (
 				os.Getenv("SNAP"),
 				os.Getenv("SNAP_DATA"),
 			)
-			l := k8sinit.NewLauncher(s)
+			l := k8sinit.NewLauncher(s, initPreInit)
 
 			var (
 				b   []byte
@@ -58,6 +59,7 @@ var (
 
 func init() {
 	initCmd.Flags().StringVarP(&initInputFile, "config-file", "c", initInputFile, "configuration file to read, or '-' to read from stdin")
+	initCmd.Flags().BoolVarP(&initPreInit, "pre-init", "p", initPreInit, "apply pre-init configuration, do not restart services or manage addons")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/pkg/k8sinit/apply.go
+++ b/pkg/k8sinit/apply.go
@@ -3,6 +3,8 @@ package k8sinit
 import (
 	"context"
 	"fmt"
+
+	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
 )
 
 // Apply applies a multi-part configuration to the local MicroK8s node.
@@ -25,6 +27,8 @@ func (l *Launcher) applyPart(ctx context.Context, c *Configuration) error {
 		l.reconcileAddons(ctx, c.Addons)
 	}
 
+	if err := l.reconcileKubeletArgs(ctx, c.ExtraKubeletArgs); err != nil {
+		return fmt.Errorf("failed to configure extra kubelet args: %w", err)
 	}
 
 	return nil
@@ -40,5 +44,35 @@ func (l *Launcher) reconcileAddons(ctx context.Context, addons []AddonConfigurat
 			return fmt.Errorf("failed to enable addon %q: %w", addon.Name, err)
 		}
 	}
+	return nil
+}
+
+func (l *Launcher) reconcileKubeletArgs(ctx context.Context, args map[string]*string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	updateArgs := map[string]string{}
+	deleteArgs := []string{}
+
+	for key, valptr := range args {
+		if valptr == nil {
+			deleteArgs = append(deleteArgs, key)
+		} else {
+			updateArgs[key] = *valptr
+		}
+	}
+
+	changed, err := snaputil.UpdateServiceArguments(l.snap, "kubelet", []map[string]string{updateArgs}, deleteArgs)
+	if err != nil {
+		return fmt.Errorf("failed to update service arguments: %w", err)
+	}
+
+	// TODO(neoaggelos): restart services should be deferred until the very end of the function
+	if changed && !l.preInit {
+		if err := l.snap.RestartService(ctx, "kubelet"); err != nil {
+			return fmt.Errorf("failed to restart kubelet service after updating arguments: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/k8sinit/apply.go
+++ b/pkg/k8sinit/apply.go
@@ -24,7 +24,9 @@ func (l *Launcher) applyPart(ctx context.Context, c *Configuration) error {
 	}
 
 	if !l.preInit {
-		l.reconcileAddons(ctx, c.Addons)
+		if err := l.reconcileAddons(ctx, c.Addons); err != nil {
+			return fmt.Errorf("failed to reconcile addons: %w", err)
+		}
 	}
 
 	if err := l.reconcileKubeletArgs(ctx, c.ExtraKubeletArgs); err != nil {

--- a/pkg/k8sinit/apply.go
+++ b/pkg/k8sinit/apply.go
@@ -21,24 +21,24 @@ func (l *Launcher) applyPart(ctx context.Context, c *Configuration) error {
 		return nil
 	}
 
-	for _, addon := range c.Addons {
-		if err := l.applyAddon(ctx, addon); err != nil {
-			return fmt.Errorf("failed to apply addon %q: %w", addon.Name, err)
-		}
+	if !l.preInit {
+		l.reconcileAddons(ctx, c.Addons)
+	}
+
 	}
 
 	return nil
 }
 
-func (l *Launcher) applyAddon(ctx context.Context, c AddonConfiguration) error {
-	f := l.snap.EnableAddon
-	if c.Disable {
-		f = l.snap.DisableAddon
+func (l *Launcher) reconcileAddons(ctx context.Context, addons []AddonConfiguration) error {
+	for _, addon := range addons {
+		if addon.Disable {
+			if err := l.snap.DisableAddon(ctx, addon.Name, addon.Arguments...); err != nil {
+				return fmt.Errorf("failed to disable addon %q: %w", addon.Name, err)
+			}
+		} else if err := l.snap.EnableAddon(ctx, addon.Name, addon.Arguments...); err != nil {
+			return fmt.Errorf("failed to enable addon %q: %w", addon.Name, err)
+		}
 	}
-
-	if err := f(ctx, c.Name, c.Arguments...); err != nil {
-		return fmt.Errorf("addon operation failed: %w", err)
-	}
-
 	return nil
 }

--- a/pkg/k8sinit/launcher.go
+++ b/pkg/k8sinit/launcher.go
@@ -6,10 +6,12 @@ import (
 
 // Launcher is used to apply launch configurations to the MicroK8s cluster.
 type Launcher struct {
-	snap snap.Snap
+	snap    snap.Snap
+	preInit bool
 }
 
 // NewLauncher creates a new launcher instance.
-func NewLauncher(s snap.Snap) *Launcher {
-	return &Launcher{snap: s}
+// preInit is true when applying the configuration prior to any of the services running.
+func NewLauncher(s snap.Snap, preInit bool) *Launcher {
+	return &Launcher{snap: s, preInit: preInit}
 }

--- a/pkg/k8sinit/launcher_test.go
+++ b/pkg/k8sinit/launcher_test.go
@@ -34,7 +34,7 @@ func TestAddons(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &mock.Snap{}
 
-			l := NewLauncher(s)
+			l := NewLauncher(s, false)
 			c := MultiPartConfiguration{[]*Configuration{
 				{Version: minimumConfigFileVersionRequired.String(), Addons: tc.addons},
 			}}

--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -46,6 +46,10 @@ type Configuration struct {
 	// ExtraKubeletArgs is a list of extra arguments to add to the local node kubelet.
 	// Set a value to null to remove it from the arguments.
 	ExtraKubeletArgs map[string]*string `yaml:"extraKubeletArgs"`
+
+	// ExtraKubeAPIServerArgs is a list of extra arguments to add to the local node kube-apiserver.
+	// Set a value to null to remove it from the arguments.
+	ExtraKubeAPIServerArgs map[string]*string `yaml:"extraKubeAPIServerArgs"`
 }
 
 // ParseConfiguration tries to parse a Configuration object from YAML data.

--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -42,6 +42,10 @@ type Configuration struct {
 
 	// Addons is a list of addons to enable and/or disable.
 	Addons []AddonConfiguration `yaml:"addons"`
+
+	// ExtraKubeletArgs is a list of extra arguments to add to the local node kubelet.
+	// Set a value to null to remove it from the arguments.
+	ExtraKubeletArgs map[string]*string `yaml:"extraKubeletArgs"`
 }
 
 // ParseConfiguration tries to parse a Configuration object from YAML data.

--- a/pkg/util/exec.go
+++ b/pkg/util/exec.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -14,6 +15,8 @@ func RunCommand(ctx context.Context, command ...string) error {
 		args = command[1:]
 	}
 	cmd := exec.CommandContext(ctx, command[0], args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("command %v failed with exit code %d: %w", command, cmd.ProcessState.ExitCode(), err)
 	}


### PR DESCRIPTION
## Summary

Add `cluster-agent init --pre-init` mode, which only applies initial configurations. This is meant to run before any MicroK8s services have started, for initial configuration (e.g. configure cloud-provider, set node labels, etc).

## Implementation

In pre-init mode, the following things are changed:

- Addons are ignored, since they require services to be running.
- When changing config files, services are not restarted.

As reference implementation, add `ExtraKubeletArgs` and `ExtraKubeAPIServerArgs` configuration.

## Notes

Also added a QOL change, when enabling addons, the microk8s enable/disable command output is no longer being supressed.