### PR TITLE
Fix parsing of empty YAML documents

### DIFF
--- a/pkg/k8sinit/schema_test.go
+++ b/pkg/k8sinit/schema_test.go
@@ -41,6 +41,15 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name: "multi-part-with-header.yaml",
+			expectConfiguration: k8sinit.MultiPartConfiguration{
+				Parts: []*k8sinit.Configuration{
+					{Version: "0.1.0", Addons: []k8sinit.AddonConfiguration{{Name: "dns"}}},
+					{Version: "0.1.0", Addons: []k8sinit.AddonConfiguration{{Name: "rbac"}}},
+				},
+			},
+		},
+		{
 			name: "unknown-fields.yaml",
 			expectConfiguration: k8sinit.MultiPartConfiguration{
 				Parts: []*k8sinit.Configuration{{

--- a/pkg/k8sinit/testdata/schema/multi-part-with-header.yaml
+++ b/pkg/k8sinit/testdata/schema/multi-part-with-header.yaml
@@ -1,0 +1,9 @@
+# example doc with header comment
+---
+version: 0.1.0
+addons:
+  - name: dns
+---
+version: 0.1.0
+addons:
+  - name: rbac


### PR DESCRIPTION
### Summary

Fixes

```
could not parse config file version \"\": could not parse \"\" as version
```

when given the following input:

```yaml
# some example header
---
version: 0.1.0
addons:
  - name: dns
```

This is because the YAML reader considers the first comment a separate YAML (empty) document, only containing the comment.

### Testing

Added a new unit test to cover regressions.