### PR TITLE
Add ExtraSANs init configuration

### DIFF
--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -54,6 +54,9 @@ type Configuration struct {
 	// ExtraKubeAPIServerArgs is a list of extra arguments to add to the local node kube-apiserver.
 	// Set a value to null to remove it from the arguments.
 	ExtraKubeAPIServerArgs map[string]*string `yaml:"extraKubeAPIServerArgs"`
+
+	// ExtraSANs are a list of extra Subject Alternate Names to add to the local API server.
+	ExtraSANs []string `yaml:"extraSANs"`
 }
 
 // ParseConfiguration tries to parse a Configuration object from YAML data.
@@ -121,5 +124,6 @@ func (c *Configuration) isZero() bool {
 	return c.Version == "" &&
 		len(c.Addons) == 0 &&
 		len(c.ExtraKubeAPIServerArgs) == 0 &&
-		len(c.ExtraKubeletArgs) == 0
+		len(c.ExtraKubeletArgs) == 0 &&
+		len(c.ExtraSANs) == 0
 }

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -91,4 +91,7 @@ type Snap interface {
 
 	// ImportImage imports an OCI image from raw bytes.
 	ImportImage(ctx context.Context, reader io.Reader) error
+
+	// WriteCSRConfig updates the csr.conf.template file on the local node.
+	WriteCSRConfig(csrConf []byte) error
 }

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -62,6 +62,8 @@ type Snap struct {
 	SignedCertificate         string
 
 	ImportImageCalledWith []string // string(io.ReadAll(reader))
+
+	CSRConfig string
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.
@@ -306,6 +308,12 @@ func (s *Snap) ImportImage(ctx context.Context, reader io.Reader) error {
 	}
 	b, _ := io.ReadAll(reader)
 	s.ImportImageCalledWith = append(s.ImportImageCalledWith, string(b))
+	return nil
+}
+
+// WriteCSRConfig is a mock implementation for the snap.Snap interface.
+func (s *Snap) WriteCSRConfig(b []byte) error {
+	s.CSRConfig = string(b)
 	return nil
 }
 

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -341,4 +341,8 @@ func (s *snap) ImportImage(ctx context.Context, reader io.Reader) error {
 	return nil
 }
 
+func (s *snap) WriteCSRConfig(csrConf []byte) error {
+	return os.WriteFile(s.snapDataPath("certs", "csr.conf.template"), csrConf, 0660)
+}
+
 var _ Snap = &snap{}

--- a/pkg/snap/snap_files_test.go
+++ b/pkg/snap/snap_files_test.go
@@ -75,6 +75,7 @@ func TestFiles(t *testing.T) {
 	}{
 		{name: "CNI", write: s.WriteCNIYaml, file: "testdata/args/cni-network/cni.yaml"},
 		{name: "DqliteUpdateYaml", write: s.WriteDqliteUpdateYaml, file: "testdata/var/kubernetes/backend/update.yaml"},
+		{name: "WriteCSRConfig", write: s.WriteCSRConfig, file: "testdata/certs/csr.conf.template"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			magicVal := util.NewRandomString(util.Alpha, 10)

--- a/pkg/util/csr.go
+++ b/pkg/util/csr.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"text/template"
+)
+
+var csrConfTemplate = template.Must(template.New("csrConf").Parse(`
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+C = GB
+ST = Canonical
+L = Canonical
+O = Canonical
+OU = Canonical
+CN = 127.0.0.1
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+{{ range $i, $a := .DNSNames }}DNS.{{ $i }} = {{ $a }}
+{{ end }}
+
+{{ range $i, $a := .IPAddresses }}IP.{{ $i }} = {{ $a }}
+{{ end }}
+#MOREIPS
+
+[ v3_ext ]
+authorityKeyIdentifier=keyid,issuer:always
+basicConstraints=CA:FALSE
+keyUsage=keyEncipherment,dataEncipherment,digitalSignature
+extendedKeyUsage=serverAuth,clientAuth
+subjectAltName=@alt_names
+`))
+
+type templateData struct {
+	IPAddresses []string
+	DNSNames    []string
+}
+
+// GenerateCSRConf generates a csr.conf.template file for the MicroK8s node.
+// extraSANs are a list of extra Subject Alternate Names to be added to the certificates.
+func GenerateCSRConf(extraSANs []string) ([]byte, error) {
+	ips := []string{"127.0.0.1", "10.152.183.1"}
+	dns := []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.cluster", "kubernetes.default.svc.cluster.local"}
+	for _, v := range extraSANs {
+		if net.ParseIP(v) == nil {
+			dns = append(dns, v)
+		} else {
+			ips = append(ips, v)
+		}
+	}
+	var b bytes.Buffer
+	if err := csrConfTemplate.Execute(&b, templateData{IPAddresses: ips, DNSNames: dns}); err != nil {
+		return nil, fmt.Errorf("failed to render csr.conf.template: %w", err)
+	}
+
+	return b.Bytes(), nil
+}

--- a/pkg/util/csr_test.go
+++ b/pkg/util/csr_test.go
@@ -1,0 +1,22 @@
+package util_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/canonical/microk8s-cluster-agent/pkg/util"
+)
+
+func TestGenerateCSRConf(t *testing.T) {
+	b, err := util.GenerateCSRConf([]string{"10.10.10.10", "microk8s.example.com"})
+	if err != nil {
+		t.Fatalf("did not expect an error but got %q", err)
+	}
+
+	if found := bytes.Contains(b, []byte("\nIP.2 = 10.10.10.10\n")); !found {
+		t.Fatalf("expected IP address 10.10.10.10 SAN but it was not there")
+	}
+	if found := bytes.Contains(b, []byte("\nDNS.5 = microk8s.example.com\n")); !found {
+		t.Fatalf("expected DNS name microk8s.example.com SAN but it was not there")
+	}
+}


### PR DESCRIPTION
### Summary

Add ExtraSANs to configuration schema, and implement `snap.WriteCSRConfig()`.

This can be used to configure extra subject alternate names for the apiserver certificates.

### Testing

Unit tests for CSR file rendering, file creation and schema parsing. Added gomega for testing the schema, which improves the error messages.