### PR TITLE
Containerd Registries configuration

### DIFF
--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -69,6 +69,9 @@ type Configuration struct {
 
 	// ExtraSANs are a list of extra Subject Alternate Names to add to the local API server.
 	ExtraSANs []string `yaml:"extraSANs"`
+
+	// ContainerdRegistryConfigs is containerd hosts.toml configurations to configure registries.
+	ContainerdRegistryConfigs map[string]string `yaml:"containerdRegistryConfigs"`
 }
 
 // ParseConfiguration tries to parse a Configuration object from YAML data.
@@ -140,5 +143,6 @@ func (c *Configuration) isZero() bool {
 		len(c.ExtraKubeProxyArgs) == 0 &&
 		len(c.ExtraKubeControllerManagerArgs) == 0 &&
 		len(c.ExtraKubeSchedulerArgs) == 0 &&
-		len(c.ExtraSANs) == 0
+		len(c.ExtraSANs) == 0 &&
+		len(c.ContainerdRegistryConfigs) == 0
 }

--- a/pkg/k8sinit/schema_test.go
+++ b/pkg/k8sinit/schema_test.go
@@ -51,6 +51,9 @@ func TestParse(t *testing.T) {
 						{Name: "mayastor", Disable: false, Arguments: []string{"--default-pool-size", "20GB"}},
 						{Name: "registry", Disable: true},
 					},
+					ContainerdRegistryConfigs: map[string]string{
+						"docker.io": `server = "http://my.proxy:5000"`,
+					},
 				}},
 			},
 		},

--- a/pkg/k8sinit/testdata/schema/full.yaml
+++ b/pkg/k8sinit/testdata/schema/full.yaml
@@ -22,3 +22,5 @@ addons:
     args: [--default-pool-size, 20GB]
   - name: registry
     disable: true
+containerdRegistryConfigs:
+  docker.io: server = "http://my.proxy:5000"

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -94,4 +94,8 @@ type Snap interface {
 
 	// WriteCSRConfig updates the csr.conf.template file on the local node.
 	WriteCSRConfig(csrConf []byte) error
+
+	// UpdateContainerdRegistryConfigs writes hosts.toml registry configurations for containerd.
+	// Accepts a map where key is the registry (e.g. "docker.io") and the value is the contents of the hosts.toml file.
+	UpdateContainerdRegistryConfigs(configs map[string][]byte) error
 }

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -64,6 +64,8 @@ type Snap struct {
 	ImportImageCalledWith []string // string(io.ReadAll(reader))
 
 	CSRConfig string
+
+	ContainerdRegistryConfigs map[string]string // map registry name to hosts.toml contents
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.
@@ -314,6 +316,17 @@ func (s *Snap) ImportImage(ctx context.Context, reader io.Reader) error {
 // WriteCSRConfig is a mock implementation for the snap.Snap interface.
 func (s *Snap) WriteCSRConfig(b []byte) error {
 	s.CSRConfig = string(b)
+	return nil
+}
+
+// UpdateContainerdRegistryConfigs is a mock implementation for the snap.Snap interface.
+func (s *Snap) UpdateContainerdRegistryConfigs(cfgs map[string][]byte) error {
+	if s.ContainerdRegistryConfigs == nil {
+		s.ContainerdRegistryConfigs = make(map[string]string)
+	}
+	for k, v := range cfgs {
+		s.ContainerdRegistryConfigs[k] = string(v)
+	}
 	return nil
 }
 

--- a/pkg/snap/snap_containerd_test.go
+++ b/pkg/snap/snap_containerd_test.go
@@ -1,0 +1,43 @@
+package snap_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpdateContainerdRegistryConfigs(t *testing.T) {
+	if err := os.MkdirAll("testdata/args", 0755); err != nil {
+		t.Fatalf("Failed to create test directory: %s", err)
+	}
+	defer os.RemoveAll("testdata/args")
+
+	s := snap.NewSnap("testdata", "testdata")
+
+	t.Run("Mirror", func(t *testing.T) {
+		g := NewWithT(t)
+		err := s.UpdateContainerdRegistryConfigs(map[string][]byte{
+			"docker.io": []byte(`server = "http://dockerhub.mirror:32000"`),
+			"quay.io":   []byte(`server = "http://quay.mirror:32000"`),
+		})
+		g.Expect(err).To(BeNil())
+
+		b, err := os.ReadFile("testdata/args/certs.d/docker.io/hosts.toml")
+		g.Expect(err).To(BeNil())
+		g.Expect(b).To(Equal([]byte(`server = "http://dockerhub.mirror:32000"`)))
+
+		b, err = os.ReadFile("testdata/args/certs.d/quay.io/hosts.toml")
+		g.Expect(err).To(BeNil())
+		g.Expect(b).To(Equal([]byte(`server = "http://quay.mirror:32000"`)))
+	})
+
+	t.Run("BadPath", func(t *testing.T) {
+		g := NewWithT(t)
+		err := s.UpdateContainerdRegistryConfigs(map[string][]byte{
+			"../path/traversal": []byte(`server = "http://dockerhub.mirror:32000"`),
+		})
+		g.Expect(err).NotTo(BeNil())
+	})
+}


### PR DESCRIPTION
### Summary

Configure `hosts.toml` for registries using launch configurations.


### Testing

Unit tests, test locally.

### Example

Example config:

```yaml
version: 0.1.0
containerdRegistryConfigs:
  docker.io: |
    server = "http://dockerhub.mirror:5000"
```

NOTE: Review after #18 