### PR TITLE
Configure addon repositories with launch configurations

### DIFF
--- a/pkg/k8sinit/launcher_test.go
+++ b/pkg/k8sinit/launcher_test.go
@@ -33,18 +33,27 @@ func TestAddons(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			s := &mock.Snap{}
+			for _, preInit := range []bool{false, true} {
+				t.Run(fmt.Sprintf("preInit=%v", preInit), func(t *testing.T) {
+					s := &mock.Snap{}
 
-			l := NewLauncher(s, false)
-			c := MultiPartConfiguration{[]*Configuration{
-				{Version: minimumConfigFileVersionRequired.String(), Addons: tc.addons},
-			}}
-			g := NewWithT(t)
-			err := l.Apply(context.Background(), c)
-			g.Expect(err).To(BeNil())
+					l := NewLauncher(s, preInit)
+					c := MultiPartConfiguration{[]*Configuration{
+						{Version: minimumConfigFileVersionRequired.String(), Addons: tc.addons},
+					}}
+					g := NewWithT(t)
+					err := l.Apply(context.Background(), c)
+					g.Expect(err).To(BeNil())
 
-			g.Expect(s.EnableAddonCalledWith).To(Equal(tc.expectEnableAddons))
-			g.Expect(s.DisableAddonCalledWith).To(Equal(tc.expectDisableAddons))
+					if !preInit {
+						g.Expect(s.EnableAddonCalledWith).To(Equal(tc.expectEnableAddons))
+						g.Expect(s.DisableAddonCalledWith).To(Equal(tc.expectDisableAddons))
+					} else {
+						g.Expect(s.EnableAddonCalledWith).To(BeEmpty())
+						g.Expect(s.DisableAddonCalledWith).To(BeEmpty())
+					}
+				})
+			}
 		})
 	}
 }
@@ -68,17 +77,25 @@ func TestAddonRepositories(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			s := &mock.Snap{}
+			for _, preInit := range []bool{false, true} {
+				t.Run(fmt.Sprintf("preInit=%v", preInit), func(t *testing.T) {
+					s := &mock.Snap{}
 
-			l := NewLauncher(s, false)
-			c := MultiPartConfiguration{[]*Configuration{
-				{Version: minimumConfigFileVersionRequired.String(), AddonRepositories: tc.repos},
-			}}
-			g := NewWithT(t)
-			err := l.Apply(context.Background(), c)
-			g.Expect(err).To(BeNil())
+					l := NewLauncher(s, preInit)
+					c := MultiPartConfiguration{[]*Configuration{
+						{Version: minimumConfigFileVersionRequired.String(), AddonRepositories: tc.repos},
+					}}
+					g := NewWithT(t)
+					err := l.Apply(context.Background(), c)
+					g.Expect(err).To(BeNil())
 
-			g.Expect(s.AddonRepositories).To(Equal(tc.expectRepos))
+					if !preInit {
+						g.Expect(s.AddonRepositories).To(Equal(tc.expectRepos))
+					} else {
+						g.Expect(s.AddonRepositories).To(BeEmpty())
+					}
+				})
+			}
 		})
 	}
 }

--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -33,6 +33,16 @@ type AddonConfiguration struct {
 	Arguments []string `yaml:"args"`
 }
 
+// AddonRepositoryConfiguration specifies an addon repository to be added.
+type AddonRepositoryConfiguration struct {
+	// Name of the addon repository.
+	Name string `yaml:"name"`
+	// URL of the addon repository.
+	URL string `yaml:"url"`
+	// Reference is an optional reference to check out instead of the default branch.
+	Reference string `yaml:"reference"`
+}
+
 // MultiPartConfiguration is a configuration split into multiple parts.
 type MultiPartConfiguration struct {
 	// Parts are configuration objects that are meant to be applied in order.
@@ -43,6 +53,9 @@ type MultiPartConfiguration struct {
 type Configuration struct {
 	// Version is the semantic version of the configuration file format.
 	Version string `yaml:"version"`
+
+	// AddonRepositories is extra addon repositories to configure on the local node.
+	AddonRepositories []AddonRepositoryConfiguration `yaml:"addonRepositories"`
 
 	// Addons is a list of addons to enable and/or disable.
 	Addons []AddonConfiguration `yaml:"addons"`
@@ -189,6 +202,8 @@ func ParseMultiPartConfiguration(b []byte) (MultiPartConfiguration, error) {
 func (c *Configuration) isZero() bool {
 	switch {
 	case c.Version != "":
+		return false
+	case len(c.AddonRepositories) > 0:
 		return false
 	case len(c.Addons) > 0:
 		return false

--- a/pkg/k8sinit/schema_test.go
+++ b/pkg/k8sinit/schema_test.go
@@ -68,6 +68,10 @@ func TestParse(t *testing.T) {
 						"LIBRAFT_TRACE":   &[]string{"1"}[0],
 						"LIBDQLITE_TRACE": &[]string{"1"}[0],
 					},
+					AddonRepositories: []k8sinit.AddonRepositoryConfiguration{
+						{Name: "core", URL: "https://github.com/canonical/microk8s-core-addons"},
+						{Name: "community", URL: "/snap/microk8s/current/addons/community", Reference: "1.26"},
+					},
 				}},
 			},
 		},

--- a/pkg/k8sinit/testdata/schema/full.yaml
+++ b/pkg/k8sinit/testdata/schema/full.yaml
@@ -32,5 +32,11 @@ addons:
     args: [--default-pool-size, 20GB]
   - name: registry
     disable: true
+addonRepositories:
+  - name: core
+    url: https://github.com/canonical/microk8s-core-addons
+  - name: community
+    url: /snap/microk8s/current/addons/community
+    reference: 1.26
 containerdRegistryConfigs:
   docker.io: server = "http://my.proxy:5000"

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -98,4 +98,7 @@ type Snap interface {
 	// UpdateContainerdRegistryConfigs writes hosts.toml registry configurations for containerd.
 	// Accepts a map where key is the registry (e.g. "docker.io") and the value is the contents of the hosts.toml file.
 	UpdateContainerdRegistryConfigs(configs map[string][]byte) error
+
+	// AddAddonsRepository configures an addons repository on the local node, similar to running the 'microk8s addons repo add' command.
+	AddAddonsRepository(ctx context.Context, name, url, reference string, force bool) error
 }

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -10,6 +10,13 @@ import (
 	"github.com/canonical/microk8s-cluster-agent/pkg/util"
 )
 
+// AddonRepository is a mock for the current state of an addon repository.
+type AddonRepository struct {
+	URL       string
+	Reference string
+	Force     bool
+}
+
 // Snap is a generic mock for the snap.Snap interface.
 type Snap struct {
 	GroupName string
@@ -66,6 +73,8 @@ type Snap struct {
 	CSRConfig string
 
 	ContainerdRegistryConfigs map[string]string // map registry name to hosts.toml contents
+
+	AddonRepositories map[string]AddonRepository
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.
@@ -326,6 +335,20 @@ func (s *Snap) UpdateContainerdRegistryConfigs(cfgs map[string][]byte) error {
 	}
 	for k, v := range cfgs {
 		s.ContainerdRegistryConfigs[k] = string(v)
+	}
+	return nil
+}
+
+// AddAddonsRepository is a mock implementation for the snap.Snap interface.
+func (s *Snap) AddAddonsRepository(ctx context.Context, name, url, reference string, force bool) error {
+	if s.AddonRepositories == nil {
+		s.AddonRepositories = make(map[string]AddonRepository)
+	}
+
+	s.AddonRepositories[name] = AddonRepository{
+		URL:       url,
+		Reference: reference,
+		Force:     force,
 	}
 	return nil
 }

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -373,4 +373,18 @@ func (s *snap) UpdateContainerdRegistryConfigs(configs map[string][]byte) error 
 	return nil
 }
 
+func (s *snap) AddAddonsRepository(ctx context.Context, name, url, reference string, force bool) error {
+	cmd := []string{filepath.Join(s.snapPath("microk8s-addons.wrapper")), "repo", "add", name, url}
+	if reference != "" {
+		cmd = append(cmd, "--reference", reference)
+	}
+	if force {
+		cmd = append(cmd, "--force")
+	}
+	if err := s.runCommand(ctx, cmd...); err != nil {
+		return fmt.Errorf("failed to execute addons repo add command: %w", err)
+	}
+	return nil
+}
+
 var _ Snap = &snap{}

--- a/pkg/snap/snap_addons_test.go
+++ b/pkg/snap/snap_addons_test.go
@@ -1,0 +1,52 @@
+package snap_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
+	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
+)
+
+func TestAddons(t *testing.T) {
+	t.Run("EnableDisable", func(t *testing.T) {
+		runner := &utiltest.MockRunner{}
+		s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(runner.Run))
+
+		s.EnableAddon(context.Background(), "dns")
+		s.EnableAddon(context.Background(), "dns", "10.0.0.2")
+		s.DisableAddon(context.Background(), "rbac")
+		s.DisableAddon(context.Background(), "storage", "--destroy")
+
+		expectedCommands := []string{
+			"testdata/microk8s-enable.wrapper dns",
+			"testdata/microk8s-enable.wrapper dns 10.0.0.2",
+			"testdata/microk8s-disable.wrapper rbac",
+			"testdata/microk8s-disable.wrapper storage --destroy",
+		}
+		if !reflect.DeepEqual(expectedCommands, runner.CalledWithCommand) {
+			t.Fatalf("Expected commands %#v, but received %#v", expectedCommands, runner.CalledWithCommand)
+		}
+	})
+
+	t.Run("AddRepository", func(t *testing.T) {
+		runner := &utiltest.MockRunner{}
+		s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(runner.Run))
+
+		s.AddAddonsRepository(context.Background(), "core", "/snap/microk8s/current/addons/core", "", false)
+		s.AddAddonsRepository(context.Background(), "core", "/snap/microk8s/current/addons/core", "", true)
+		s.AddAddonsRepository(context.Background(), "core", "https://github.com/canonical/microk8s-core-addons", "1.26", false)
+		s.AddAddonsRepository(context.Background(), "community", "https://github.com/canonical/microk8s-community-addons", "1.26", true)
+
+		expectedCommands := []string{
+			"testdata/microk8s-addons.wrapper repo add core /snap/microk8s/current/addons/core",
+			"testdata/microk8s-addons.wrapper repo add core /snap/microk8s/current/addons/core --force",
+			"testdata/microk8s-addons.wrapper repo add core https://github.com/canonical/microk8s-core-addons --reference 1.26",
+			"testdata/microk8s-addons.wrapper repo add community https://github.com/canonical/microk8s-community-addons --reference 1.26 --force",
+		}
+		if !reflect.DeepEqual(expectedCommands, runner.CalledWithCommand) {
+			t.Fatalf("Expected commands %#v, but received %#v", expectedCommands, runner.CalledWithCommand)
+		}
+	})
+}


### PR DESCRIPTION
### Summary

Configure addon repositories using launch configurations

Example configuration:

```yaml
---
version: 0.1.0
addonRepositories:
  - name: core
    url: https://github.com/canonical/microk8s-core-addons
    reference: fix/my-bug
  - name: community
    url: /snap/microk8s/current/addons/community
addons:
  - name: community/argocd
```
