### PR TITLE
Do not fail in update arguments if file does not exist

### DIFF
--- a/pkg/snap/util/services.go
+++ b/pkg/snap/util/services.go
@@ -1,7 +1,9 @@
 package snaputil
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
@@ -61,7 +63,7 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 	}
 
 	arguments, err := s.ReadServiceArguments(serviceName)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return false, fmt.Errorf("failed to read arguments of service %s: %w", serviceName, err)
 	}
 


### PR DESCRIPTION
### Summary

`UpdateServiceArguments` should not fail if the file does not yet exist.

### Notes

- Add a test case for the specific scenario
- Take this chance to also cleanup the tests and use gomega instead.