### PR TITLE
Fix join issues when dqlite cluster is still coming up

### DIFF
--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -107,7 +107,9 @@ func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, er
 
 	// Check node is not in cluster already.
 	a.dqliteMu.Lock()
-	dqliteCluster, err := snaputil.GetDqliteCluster(a.Snap)
+	dqliteCluster, err := snaputil.WaitForDqliteCluster(ctx, a.Snap, func(c snaputil.DqliteCluster) (bool, error) {
+		return len(c) >= 1, nil
+	})
 	if err != nil {
 		a.dqliteMu.Unlock()
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to retrieve dqlite cluster nodes: %w", err)


### PR DESCRIPTION
### Summary

Fixes 

```
Connection failed. Failed to retrieve dqlite cluster nodes: failed to read list of dqlite nodes: failed to read /var/snap/microk8s/4959/var/kubernetes/backend/cluster.yaml: open /var/snap/microk8s/4959/var/kubernetes/backend/cluster.yaml: no such file or directory (500).
```