### PR TITLE
Do not break dqlite cluster if join IP address is unknown

### DIFF
--- a/cmd/cluster-agent.go
+++ b/cmd/cluster-agent.go
@@ -43,6 +43,7 @@ lifecycle of a MicroK8s cluster.`,
 		apiv2 := &v2.API{
 			Snap:                    s,
 			LookupIP:                net.LookupIP,
+			InterfaceAddrs:          net.InterfaceAddrs,
 			ListControlPlaneNodeIPs: snaputil.ListControlPlaneNodeIPs,
 		}
 		srv := server.NewServer(time.Duration(timeout)*time.Second, enableMetrics, apiv1, apiv2)

--- a/pkg/api/v2/api.go
+++ b/pkg/api/v2/api.go
@@ -19,6 +19,9 @@ type API struct {
 	// LookupIP is net.LookupIP.
 	LookupIP func(string) ([]net.IP, error)
 
+	// InterfaceAddrs is net.InterfaceAddrs.
+	InterfaceAddrs func() ([]net.Addr, error)
+
 	// dqliteMu protects changes involving the dqlite service.
 	dqliteMu sync.Mutex
 

--- a/pkg/api/v2/api_util.go
+++ b/pkg/api/v2/api_util.go
@@ -1,0 +1,51 @@
+package v2
+
+import (
+	"fmt"
+	"log"
+	"net"
+)
+
+// findMatchingBindAddress attempts to find the bind address for dqlite from the 'host:port' of the join request.
+// in case of system errors, the request host is returned, to preserve backwards-compatibility.
+func (a *API) findMatchingBindAddress(hostPort string) (string, error) {
+	requestHost, _, _ := net.SplitHostPort(hostPort)
+
+	addrs, err := a.InterfaceAddrs()
+	if err != nil {
+		log.Printf("[WARNING] failed to retrieve host addresses: %v", err)
+		log.Printf("[WARNING] will attempt to use %v as dqlite bind address", requestHost)
+		return requestHost, nil
+	}
+
+nextAddr:
+	for _, addr := range addrs {
+		ip, subnet, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			continue nextAddr
+		}
+
+		// FIXME(neoaggelos): handle the case where a virtual IP is used for the microk8s join command.
+		// in that scenario, the machine will have two IP addresses like this:
+		//     10.0.0.11/16             <-- IP address of the machine, subnet is 10.0.0.0/16
+		//     10.0.0.100/32            <-- Virtual IP, /32 address but contained in 10.0.0.0/16
+		//
+		// We should detect whether a virtual IP is used (in this case 10.0.0.100/32) and use the
+		// respective IP address instead (in this case 10.0.0.11/16).
+		//
+		// One way to do this is:
+		// - for all addresses, use subnet.Mask.Size() and check whether the subnet mask is all ones (e.g. /32 for IPv4, /128 for IPv6)
+		// - if subnet mask is not all ones, check whether subnet.Contains(requestHost)
+		//
+		// If the above conditions hold, use ip.String() instead of the requestHost (needs adjustments in the condition above)
+		_ = subnet
+
+		if ip.String() == requestHost {
+			// this is a known IP address, accept it
+			return requestHost, nil
+		}
+	}
+
+	// no host address matched
+	return "", fmt.Errorf("address %v was not found in any host interface. refuse to update dqlite bind address to %v as it would break the cluster", requestHost, requestHost)
+}

--- a/pkg/api/v2/api_util.go
+++ b/pkg/api/v2/api_util.go
@@ -9,43 +9,58 @@ import (
 // findMatchingBindAddress attempts to find the bind address for dqlite from the 'host:port' of the join request.
 // in case of system errors, the request host is returned, to preserve backwards-compatibility.
 func (a *API) findMatchingBindAddress(hostPort string) (string, error) {
-	requestHost, _, _ := net.SplitHostPort(hostPort)
+	hostIP, _, _ := net.SplitHostPort(hostPort)
+
+	hostNetIP := net.ParseIP(hostIP)
+	if hostNetIP == nil {
+		log.Printf("[WARNING] failed to parse IP address %v", hostIP)
+		log.Printf("[WARNING] will attempt to use %v as dqlite bind address", hostIP)
+		return hostIP, nil
+	}
 
 	addrs, err := a.InterfaceAddrs()
 	if err != nil {
 		log.Printf("[WARNING] failed to retrieve host addresses: %v", err)
-		log.Printf("[WARNING] will attempt to use %v as dqlite bind address", requestHost)
-		return requestHost, nil
+		log.Printf("[WARNING] will attempt to use %v as dqlite bind address", hostIP)
+		return hostIP, nil
 	}
+
+	var (
+		isVirtualIP         bool
+		matchingInterfaceIP net.IP
+	)
 
 nextAddr:
 	for _, addr := range addrs {
 		ip, subnet, err := net.ParseCIDR(addr.String())
-		if err != nil {
+		if err != nil || subnet == nil {
+			log.Printf("[WARNING] failed to parse address %v: %v", addr.String(), err)
 			continue nextAddr
 		}
 
-		// FIXME(neoaggelos): handle the case where a virtual IP is used for the microk8s join command.
-		// in that scenario, the machine will have two IP addresses like this:
-		//     10.0.0.11/16             <-- IP address of the machine, subnet is 10.0.0.0/16
-		//     10.0.0.100/32            <-- Virtual IP, /32 address but contained in 10.0.0.0/16
-		//
-		// We should detect whether a virtual IP is used (in this case 10.0.0.100/32) and use the
-		// respective IP address instead (in this case 10.0.0.11/16).
-		//
-		// One way to do this is:
-		// - for all addresses, use subnet.Mask.Size() and check whether the subnet mask is all ones (e.g. /32 for IPv4, /128 for IPv6)
-		// - if subnet mask is not all ones, check whether subnet.Contains(requestHost)
-		//
-		// If the above conditions hold, use ip.String() instead of the requestHost (needs adjustments in the condition above)
-		_ = subnet
-
-		if ip.String() == requestHost {
-			// this is a known IP address, accept it
-			return requestHost, nil
+		ones, bits := subnet.Mask.Size()
+		subnetHostBits := bits - ones
+		if ip.Equal(hostNetIP) {
+			// virtual IPs are /32 IPv4 or /128 IPv6
+			isVirtualIP = subnetHostBits == 0
+			if !isVirtualIP {
+				return hostIP, nil
+			}
+		} else if subnet.Contains(hostNetIP) && subnetHostBits > 0 {
+			// we found the IP address of the interface
+			matchingInterfaceIP = ip
 		}
 	}
 
+	if isVirtualIP {
+		if matchingInterfaceIP != nil {
+			return matchingInterfaceIP.String(), nil
+		}
+
+		// hostIP is most likely a virtual IP, but we were not able to find the matching IP address. return the IP address to maintain backwards-compatibility.
+		return hostIP, nil
+	}
+
 	// no host address matched
-	return "", fmt.Errorf("address %v was not found in any host interface. refuse to update dqlite bind address to %v as it would break the cluster", requestHost, requestHost)
+	return "", fmt.Errorf("address %v was not found in any host interface. refuse to update dqlite bind address to %v as it would break the cluster", hostIP, hostIP)
 }

--- a/pkg/api/v2/api_util_test.go
+++ b/pkg/api/v2/api_util_test.go
@@ -1,0 +1,81 @@
+package v2
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
+	. "github.com/onsi/gomega"
+)
+
+func TestStdlibPreconditions(t *testing.T) {
+	g := NewWithT(t)
+	addrs, err := net.InterfaceAddrs()
+	g.Expect(err).To(BeNil(), "net.InterfaceAddrs() must not fail")
+
+	for _, addr := range addrs {
+		ip, subnet, err := net.ParseCIDR(addr.String())
+		g.Expect(err).To(BeNil(), "net.ParseCIDR() must not fail for %v", addr.String())
+		g.Expect(ip).ToNot(BeNil(), "Address for %v must not be nil", addr.String())
+		g.Expect(subnet).ToNot(BeNil(), "Subnet for %v must not be nil", addr.String())
+	}
+}
+
+func TestFindMatchingBindAddress(t *testing.T) {
+	t.Run("FallbackOnFailure", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var interfaceAddrsCalled bool
+		a := API{
+			InterfaceAddrs: func() ([]net.Addr, error) {
+				interfaceAddrsCalled = true
+				return nil, fmt.Errorf("some error")
+			},
+		}
+
+		addr, err := a.findMatchingBindAddress("10.0.0.10:25000")
+		g.Expect(interfaceAddrsCalled).To(BeTrue())
+		g.Expect(err).To(BeNil())
+		g.Expect(addr).To(Equal("10.0.0.10"))
+	})
+
+	t.Run("FailOnMissing", func(t *testing.T) {
+		g := NewWithT(t)
+		a := API{InterfaceAddrs: net.InterfaceAddrs}
+
+		// 1.1.1.1 should almost never be a host address, this test will fail otherwise
+		addr, err := a.findMatchingBindAddress("1.1.1.1:25000")
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(addr).To(BeEmpty())
+	})
+
+	t.Run("HandleVirtualIP", func(t *testing.T) {
+		a := API{
+			InterfaceAddrs: func() ([]net.Addr, error) {
+				return []net.Addr{
+					&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
+					&utiltest.MockCIDR{CIDR: "10.0.0.10/16"},
+					&utiltest.MockCIDR{CIDR: "10.0.100.100/32"},
+				}, nil
+			},
+		}
+		t.Run("UseInterfaceIP", func(t *testing.T) {
+			g := NewWithT(t)
+
+			addr, err := a.findMatchingBindAddress("10.0.0.10:25000")
+			g.Expect(err).To(BeNil())
+			g.Expect(addr).To(Equal("10.0.0.10"))
+		})
+
+		t.Run("UseVirtualIP", func(t *testing.T) {
+			g := NewWithT(t)
+
+			addr, err := a.findMatchingBindAddress("10.0.100.100:25000")
+			g.Expect(err).To(BeNil())
+
+			// FIXME(neoaggelos): update after we implement proper handling for Virtual IPs
+			g.Expect(addr).To(Equal("10.0.100.100"))
+		})
+	})
+}

--- a/pkg/api/v2/api_util_test.go
+++ b/pkg/api/v2/api_util_test.go
@@ -56,7 +56,9 @@ func TestFindMatchingBindAddress(t *testing.T) {
 				return []net.Addr{
 					&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
 					&utiltest.MockCIDR{CIDR: "10.0.0.10/16"},
+					&utiltest.MockCIDR{CIDR: "10.10.0.10/16"},
 					&utiltest.MockCIDR{CIDR: "10.0.100.100/32"},
+					&utiltest.MockCIDR{CIDR: "192.168.100.100/32"},
 				}, nil
 			},
 		}
@@ -73,9 +75,15 @@ func TestFindMatchingBindAddress(t *testing.T) {
 
 			addr, err := a.findMatchingBindAddress("10.0.100.100:25000")
 			g.Expect(err).To(BeNil())
+			g.Expect(addr).To(Equal("10.0.0.10"))
+		})
 
-			// FIXME(neoaggelos): update after we implement proper handling for Virtual IPs
-			g.Expect(addr).To(Equal("10.0.100.100"))
+		t.Run("FallbackToVirtualIPIfSubnetNotFound", func(t *testing.T) {
+			g := NewWithT(t)
+
+			addr, err := a.findMatchingBindAddress("192.168.100.100:25000")
+			g.Expect(err).To(BeNil())
+			g.Expect(addr).To(Equal("192.168.100.100"))
 		})
 	})
 }

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -10,6 +10,7 @@ import (
 
 	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
+	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
 )
 
 // TestJoin tests responses when joining control plane and worker nodes in an existing cluster.
@@ -56,6 +57,12 @@ Role: 0
 				"test-control-plane": {{10, 10, 10, 13}},
 				"test-worker":        {{10, 10, 10, 12}},
 			}[hostname], nil
+		},
+		InterfaceAddrs: func() ([]net.Addr, error) {
+			return []net.Addr{
+				&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
+				&utiltest.MockCIDR{CIDR: "10.0.0.10/16"},
+			}, nil
 		},
 		ListControlPlaneNodeIPs: mockListControlPlaneNodes("10.0.0.1", "10.0.0.2"),
 	}
@@ -203,6 +210,12 @@ Role: 0
 		Snap: s,
 		LookupIP: func(hostname string) ([]net.IP, error) {
 			return []net.IP{{10, 10, 10, 13}}, nil
+		},
+		InterfaceAddrs: func() ([]net.Addr, error) {
+			return []net.Addr{
+				&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
+				&utiltest.MockCIDR{CIDR: "10.10.10.10/16"},
+			}, nil
 		},
 	}
 

--- a/pkg/util/test/mock_cidr.go
+++ b/pkg/util/test/mock_cidr.go
@@ -1,0 +1,20 @@
+package utiltest
+
+import "net"
+
+// MockCIDR is a mock net.Addr
+type MockCIDR struct {
+	CIDR string
+}
+
+// Network implements net.Addr
+func (v *MockCIDR) Network() string {
+	return ""
+}
+
+// String implements net.Addr
+func (v *MockCIDR) String() string {
+	return v.CIDR
+}
+
+var _ net.Addr = &MockCIDR{}


### PR DESCRIPTION
### Summary

Check whether the new bind address for dqlite is a known host address, and fail if it is not.

Also improves the handling for joining a microk8s node using a /32 virtual IP.