### PR TITLE
Added cluster_cidr info to JoinResponse

### DIFF
--- a/pkg/api/v1/join.go
+++ b/pkg/api/v1/join.go
@@ -40,6 +40,8 @@ type JoinResponse struct {
 	KubeletArgs string `json:"kubelet_args"`
 	// HostNameOverride is the host name the joining node will be known as in the MicroK8s cluster.
 	HostNameOverride string `json:"hostname_override"`
+	// ClusterCIDR is the cidr that is used by the cluster, defined in kube-proxy args.
+	ClusterCIDR string `json:"cluster_cidr,omitempty"`
 }
 
 // Join implements "POST /CLUSTER_API_V1/join".
@@ -95,5 +97,6 @@ func (a *API) Join(ctx context.Context, request JoinRequest) (*JoinResponse, err
 		KubeletToken:         kubeletToken,
 		KubeletArgs:          kubeletArgs,
 		HostNameOverride:     hostname,
+		ClusterCIDR:          snaputil.GetServiceArgument(a.Snap, "kube-proxy", "--cluster-cidr"),
 	}, nil
 }

--- a/pkg/api/v1/join_test.go
+++ b/pkg/api/v1/join_test.go
@@ -16,6 +16,7 @@ func TestJoin(t *testing.T) {
 		ServiceArguments: map[string]string{
 			"etcd":           "--listen-client-urls=https://0.0.0.0:12379",
 			"kube-apiserver": "--secure-port 16443",
+			"kube-proxy":     "--cluster-cidr 10.1.0.0./16",
 			"kubelet":        "kubelet arguments\n",
 		},
 		ClusterTokens: []string{"valid-cluster-token", "valid-other-token"},
@@ -81,6 +82,7 @@ func TestJoin(t *testing.T) {
 			KubeletArgs:          "kubelet arguments\n\n--hostname-override=10.10.10.10",
 			KubeletToken:         resp.KubeletToken,
 			HostNameOverride:     "10.10.10.10",
+			ClusterCIDR:          "10.1.0.0./16",
 		}
 		if *resp != *expectedResponse {
 			t.Fatalf("Expected response %#v, but it was %#v", expectedResponse, resp)

--- a/pkg/api/v1/join_test.go
+++ b/pkg/api/v1/join_test.go
@@ -16,7 +16,7 @@ func TestJoin(t *testing.T) {
 		ServiceArguments: map[string]string{
 			"etcd":           "--listen-client-urls=https://0.0.0.0:12379",
 			"kube-apiserver": "--secure-port 16443",
-			"kube-proxy":     "--cluster-cidr 10.1.0.0./16",
+			"kube-proxy":     "--cluster-cidr 10.1.0.0/16",
 			"kubelet":        "kubelet arguments\n",
 		},
 		ClusterTokens: []string{"valid-cluster-token", "valid-other-token"},
@@ -82,7 +82,7 @@ func TestJoin(t *testing.T) {
 			KubeletArgs:          "kubelet arguments\n\n--hostname-override=10.10.10.10",
 			KubeletToken:         resp.KubeletToken,
 			HostNameOverride:     "10.10.10.10",
-			ClusterCIDR:          "10.1.0.0./16",
+			ClusterCIDR:          "10.1.0.0/16",
 		}
 		if *resp != *expectedResponse {
 			t.Fatalf("Expected response %#v, but it was %#v", expectedResponse, resp)

--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -75,6 +75,8 @@ type JoinResponse struct {
 	// ControlPlaneNodes is a list of known control plane nodes running kube-apiserver.
 	// This is only included in the response when joining worker-only nodes.
 	ControlPlaneNodes []string `json:"control_plane_nodes"`
+	// ClusterCidr is the cidr that is used by the cluster, defined in kube-proxy args.
+	ClusterCidr string `json:"cluster_cidr,omitempty"`
 }
 
 // Join implements "POST v2/join".
@@ -170,6 +172,7 @@ func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, er
 		APIServerAuthorizationMode: snaputil.GetServiceArgument(a.Snap, "kube-apiserver", "--authorization-mode"),
 		HostNameOverride:           remoteIP,
 		KubeletArgs:                kubeletArgs,
+		ClusterCidr:                snaputil.GetServiceArgument(a.Snap, "kube-proxy", "--cluster-cidr"),
 	}
 
 	if req.WorkerOnly {

--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -75,8 +75,8 @@ type JoinResponse struct {
 	// ControlPlaneNodes is a list of known control plane nodes running kube-apiserver.
 	// This is only included in the response when joining worker-only nodes.
 	ControlPlaneNodes []string `json:"control_plane_nodes"`
-	// ClusterCidr is the cidr that is used by the cluster, defined in kube-proxy args.
-	ClusterCidr string `json:"cluster_cidr,omitempty"`
+	// ClusterCIDR is the cidr that is used by the cluster, defined in kube-proxy args.
+	ClusterCIDR string `json:"cluster_cidr,omitempty"`
 }
 
 // Join implements "POST v2/join".
@@ -172,7 +172,7 @@ func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, er
 		APIServerAuthorizationMode: snaputil.GetServiceArgument(a.Snap, "kube-apiserver", "--authorization-mode"),
 		HostNameOverride:           remoteIP,
 		KubeletArgs:                kubeletArgs,
-		ClusterCidr:                snaputil.GetServiceArgument(a.Snap, "kube-proxy", "--cluster-cidr"),
+		ClusterCIDR:                snaputil.GetServiceArgument(a.Snap, "kube-proxy", "--cluster-cidr"),
 	}
 
 	if req.WorkerOnly {

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -40,6 +40,7 @@ Role: 0
 		ServiceArguments: map[string]string{
 			"kubelet":        "kubelet arguments\n",
 			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node,RBAC",
+			"kube-proxy":     "--cluster-cidr 10.1.0.0./16",
 			"cluster-agent":  "--bind=0.0.0.0:25000",
 		},
 		ClusterTokens:     []string{"worker-token", "control-plane-token"},
@@ -102,6 +103,7 @@ Role: 0
 			AdminToken:                 "admin-token-123",
 			DqliteClusterCertificate:   "DQLITE CERTIFICATE DATA",
 			DqliteClusterKey:           "DQLITE KEY DATA",
+			ClusterCIDR:                "10.1.0.0./16",
 		}
 		if !reflect.DeepEqual(*resp, *expectedResponse) {
 			t.Fatalf("Expected response %#v, but received %#v instead", expectedResponse, resp)
@@ -146,6 +148,7 @@ Role: 0
 			KubeletArgs:                "kubelet arguments\n",
 			HostNameOverride:           "10.10.10.12",
 			ControlPlaneNodes:          []string{"10.0.0.1", "10.0.0.2"},
+			ClusterCIDR:                "10.1.0.0./16",
 		}
 
 		if !reflect.DeepEqual(*resp, *expectedResponse) {
@@ -190,6 +193,7 @@ Role: 0
 		ServiceArguments: map[string]string{
 			"kubelet":        "kubelet arguments\n",
 			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node",
+			"kube-proxy":     "--cluster-cidr 10.1.0.0./16",
 			"cluster-agent":  "--bind=0.0.0.0:25000",
 		},
 		ClusterTokens:     []string{"control-plane-token"},
@@ -243,6 +247,7 @@ Role: 0
 		AdminToken:                 "admin-token-123",
 		DqliteClusterCertificate:   "DQLITE CERTIFICATE DATA",
 		DqliteClusterKey:           "DQLITE KEY DATA",
+		ClusterCIDR:                "10.1.0.0./16",
 	}
 	if !reflect.DeepEqual(*resp, *expectedResponse) {
 		t.Fatalf("Expected response %#v, but received %#v instead", expectedResponse, resp)

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -40,7 +40,7 @@ Role: 0
 		ServiceArguments: map[string]string{
 			"kubelet":        "kubelet arguments\n",
 			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node,RBAC",
-			"kube-proxy":     "--cluster-cidr 10.1.0.0./16",
+			"kube-proxy":     "--cluster-cidr 10.1.0.0/16",
 			"cluster-agent":  "--bind=0.0.0.0:25000",
 		},
 		ClusterTokens:     []string{"worker-token", "control-plane-token"},
@@ -103,7 +103,7 @@ Role: 0
 			AdminToken:                 "admin-token-123",
 			DqliteClusterCertificate:   "DQLITE CERTIFICATE DATA",
 			DqliteClusterKey:           "DQLITE KEY DATA",
-			ClusterCIDR:                "10.1.0.0./16",
+			ClusterCIDR:                "10.1.0.0/16",
 		}
 		if !reflect.DeepEqual(*resp, *expectedResponse) {
 			t.Fatalf("Expected response %#v, but received %#v instead", expectedResponse, resp)
@@ -148,7 +148,7 @@ Role: 0
 			KubeletArgs:                "kubelet arguments\n",
 			HostNameOverride:           "10.10.10.12",
 			ControlPlaneNodes:          []string{"10.0.0.1", "10.0.0.2"},
-			ClusterCIDR:                "10.1.0.0./16",
+			ClusterCIDR:                "10.1.0.0/16",
 		}
 
 		if !reflect.DeepEqual(*resp, *expectedResponse) {
@@ -193,7 +193,7 @@ Role: 0
 		ServiceArguments: map[string]string{
 			"kubelet":        "kubelet arguments\n",
 			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node",
-			"kube-proxy":     "--cluster-cidr 10.1.0.0./16",
+			"kube-proxy":     "--cluster-cidr 10.1.0.0/16",
 			"cluster-agent":  "--bind=0.0.0.0:25000",
 		},
 		ClusterTokens:     []string{"control-plane-token"},
@@ -247,7 +247,7 @@ Role: 0
 		AdminToken:                 "admin-token-123",
 		DqliteClusterCertificate:   "DQLITE CERTIFICATE DATA",
 		DqliteClusterKey:           "DQLITE KEY DATA",
-		ClusterCIDR:                "10.1.0.0./16",
+		ClusterCIDR:                "10.1.0.0/16",
 	}
 	if !reflect.DeepEqual(*resp, *expectedResponse) {
 		t.Fatalf("Expected response %#v, but received %#v instead", expectedResponse, resp)


### PR DESCRIPTION
Added the cidr info on the JoinResponse that's parsed from kube-proxy args.