### PR TITLE
Finalize launch configurations work

### DIFF
--- a/cmd/cluster-agent.go
+++ b/cmd/cluster-agent.go
@@ -5,10 +5,12 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	v1 "github.com/canonical/microk8s-cluster-agent/pkg/api/v1"
 	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
+	"github.com/canonical/microk8s-cluster-agent/pkg/k8sinit"
 	"github.com/canonical/microk8s-cluster-agent/pkg/server"
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
@@ -16,11 +18,13 @@ import (
 )
 
 var (
-	bind          string
-	keyfile       string
-	certfile      string
-	timeout       int
-	enableMetrics bool
+	bind                         string
+	keyfile                      string
+	certfile                     string
+	timeout                      int
+	enableMetrics                bool
+	launchConfigurationsEnable   bool
+	launchConfigurationsInterval time.Duration
 )
 
 // clusterAgentCmd represents the base command when called without any subcommands
@@ -30,12 +34,66 @@ var clusterAgentCmd = &cobra.Command{
 	Long: `The MicroK8s cluster agent is an API server that orchestrates the
 lifecycle of a MicroK8s cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		s := snap.NewSnap(
 			os.Getenv("SNAP"),
 			os.Getenv("SNAP_DATA"),
 			snap.WithRetryApplyCNI(20, 3*time.Second),
 		)
+
+		// Setup launch configuration handler
+		if launchConfigurationsEnable {
+			go func() {
+				ctx := cmd.Context()
+				log.Printf("Starting watch for launch configurations")
+
+				if launchConfigurationsInterval < 5*time.Second {
+					log.Printf("Launch configurations interval %v is less than minimum of 5s. Using the minimum 5s instead.\n", launchConfigurationsInterval)
+					launchConfigurationsInterval = 5 * time.Second
+				}
+				refreshCh := time.NewTicker(launchConfigurationsInterval).C
+
+			nextTick:
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-refreshCh:
+					}
+
+					files, err := filepath.Glob(filepath.Join(os.Getenv("SNAP_COMMON"), "etc", "launcher", "*.yaml"))
+					if err != nil {
+						log.Printf("Failed to search for launch configuration files: %v", err)
+						continue nextTick
+					}
+
+				nextFile:
+					for _, file := range files {
+						log.Printf("Applying %s", file)
+						b, err := os.ReadFile(file)
+						if err != nil {
+							log.Printf("Failed to read launch configuration file %s: %v", file, err)
+							continue nextFile
+						}
+						cfg, err := k8sinit.ParseMultiPartConfiguration(b)
+						if err != nil {
+							log.Printf("Failed to parse configuration file %s: %v", file, err)
+							continue nextFile
+						}
+						launcher := k8sinit.NewLauncher(s, false)
+						if err := launcher.Apply(ctx, cfg); err != nil {
+							log.Printf("Failed to apply configuration file %s: %v", file, err)
+							continue nextFile
+						}
+						if err := os.Rename(file, file+".applied"); err != nil {
+							log.Printf("Failed to rename applied configuration file %s: %v", file, err)
+						}
+						log.Printf("Successfully applied %s", file)
+					}
+				}
+			}()
+		}
+
+		// Setup HTTP server
 		apiv1 := &v1.API{
 			Snap:     s,
 			LookupIP: net.LookupIP,
@@ -59,6 +117,8 @@ func init() {
 	clusterAgentCmd.Flags().StringVar(&certfile, "certfile", "", "Certificate for serving TLS")
 	clusterAgentCmd.Flags().IntVar(&timeout, "timeout", 240, "Default request timeout (in seconds)")
 	clusterAgentCmd.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics endpoint")
+	clusterAgentCmd.Flags().BoolVar(&launchConfigurationsEnable, "launch-configurations-enable", true, "Enable launch configurations")
+	clusterAgentCmd.Flags().DurationVar(&launchConfigurationsInterval, "launch-configurations-interval", 5*time.Second, "Interval between checks for launch configurations")
 
 	rootCmd.AddCommand(clusterAgentCmd)
 }

--- a/pkg/k8sinit/apply.go
+++ b/pkg/k8sinit/apply.go
@@ -51,6 +51,12 @@ func (s *launcherScope) applyPart(ctx context.Context, c *Configuration) error {
 		}
 	}
 
+	if v := c.PersistentClusterToken; v != "" {
+		if err := s.launcher.snap.AddPersistentClusterToken(v); err != nil {
+			return fmt.Errorf("failed to configure persistent token: %w", err)
+		}
+	}
+
 	for file, contents := range c.ExtraConfigFiles {
 		if strings.Contains("/", file) {
 			return fmt.Errorf("file name %q must not contain any slashes (possible path-traversal prevented)", file)

--- a/pkg/k8sinit/apply.go
+++ b/pkg/k8sinit/apply.go
@@ -105,6 +105,14 @@ func (s *launcherScope) applyPart(ctx context.Context, c *Configuration) error {
 		return fmt.Errorf("failed to reconcile containerd registry configs: %w", err)
 	}
 
+	if !s.launcher.preInit {
+		if j := c.Join; j.URL != "" {
+			if err := s.launcher.snap.JoinCluster(ctx, j.URL, j.Worker); err != nil {
+				return fmt.Errorf("failed to join cluster: %w", err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/k8sinit/launcher_test.go
+++ b/pkg/k8sinit/launcher_test.go
@@ -317,6 +317,17 @@ func TestComponentConfiguration(t *testing.T) {
 			},
 			expectServiceRestart: []string{"flanneld"},
 		},
+		{
+			name: "extra-config-files",
+			setConfig: func(c *Configuration) {
+				c.ExtraConfigFiles = map[string]string{
+					"flannel-network-mgr-config": `{"Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}`,
+				}
+			},
+			expectServiceArgs: map[string][]string{
+				"flannel-network-mgr-config": {`{"Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}`},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, preInit := range []bool{false, true} {

--- a/pkg/k8sinit/launcher_test.go
+++ b/pkg/k8sinit/launcher_test.go
@@ -363,3 +363,31 @@ func TestComponentConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestPersistentClusterToken(t *testing.T) {
+	for _, withToken := range []bool{false, true} {
+		t.Run(fmt.Sprintf("withToken=%v", withToken), func(t *testing.T) {
+			for _, preInit := range []bool{false, true} {
+				t.Run(fmt.Sprintf("preInit=%v", preInit), func(t *testing.T) {
+					s := &mock.Snap{}
+
+					l := NewLauncher(s, preInit)
+					c := MultiPartConfiguration{[]*Configuration{
+						{Version: minimumConfigFileVersionRequired.String()},
+					}}
+					if withToken {
+						c.Parts[0].PersistentClusterToken = "my-token"
+					}
+					g := NewWithT(t)
+					err := l.Apply(context.Background(), c)
+					g.Expect(err).To(BeNil())
+					if withToken {
+						g.Expect(s.AddPersistentClusterTokenCalledWith).To(ConsistOf("my-token"))
+					} else {
+						g.Expect(s.AddPersistentClusterTokenCalledWith).To(BeEmpty())
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -140,6 +140,9 @@ type Configuration struct {
 	// ExtraConfigFiles is extra service configuration files to create (e.g. for configuring kube-apiserver encryption at rest).
 	// These files will be written at $SNAP_DATA/args/<filename>.
 	ExtraConfigFiles map[string]string `yaml:"extraConfigFiles"`
+
+	// PersistentClusterToken is a token that may be used to authentication join requests to the local node.
+	PersistentClusterToken string `yaml:"persistentClusterToken"`
 }
 
 // ParseConfiguration tries to parse a Configuration object from YAML data.
@@ -206,6 +209,8 @@ func ParseMultiPartConfiguration(b []byte) (MultiPartConfiguration, error) {
 func (c *Configuration) isZero() bool {
 	switch {
 	case c.Version != "":
+		return false
+	case c.PersistentClusterToken != "":
 		return false
 	case len(c.AddonRepositories) > 0:
 		return false

--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -21,6 +21,15 @@ var (
 	errEmptyConfig = fmt.Errorf("empty configuration object")
 )
 
+// JoinConfiguration is configuration to join the local node to an existing MicroK8s cluster.
+type JoinConfiguration struct {
+	// URL is the URL passed to the microk8s join command.
+	URL string `yaml:"url"`
+
+	// Worker is true when joining the cluster as a worker-only node.
+	Worker bool `yaml:"worker"`
+}
+
 // AddonConfiguration specifies an addon to be enabled or disabled.
 type AddonConfiguration struct {
 	// Name of the addon to configure.
@@ -143,6 +152,9 @@ type Configuration struct {
 
 	// PersistentClusterToken is a token that may be used to authentication join requests to the local node.
 	PersistentClusterToken string `yaml:"persistentClusterToken"`
+
+	// Join configuration. Setting this will attempt to join the local node to an already existing MicroK8s cluster.
+	Join JoinConfiguration `yaml:"join"`
 }
 
 // ParseConfiguration tries to parse a Configuration object from YAML data.
@@ -211,6 +223,10 @@ func (c *Configuration) isZero() bool {
 	case c.Version != "":
 		return false
 	case c.PersistentClusterToken != "":
+		return false
+	case c.Join.URL != "":
+		return false
+	case c.Join.Worker:
 		return false
 	case len(c.AddonRepositories) > 0:
 		return false

--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -136,6 +136,10 @@ type Configuration struct {
 	// ExtraFlanneldEnv is extra environment variables (e.g. GOFIPS) for the local node flanneld.
 	// Set a value to null to remove it from the environment.
 	ExtraFlanneldEnv map[string]*string `yaml:"extraFlanneldEnv"`
+
+	// ExtraConfigFiles is extra service configuration files to create (e.g. for configuring kube-apiserver encryption at rest).
+	// These files will be written at $SNAP_DATA/args/<filename>.
+	ExtraConfigFiles map[string]string `yaml:"extraConfigFiles"`
 }
 
 // ParseConfiguration tries to parse a Configuration object from YAML data.
@@ -246,6 +250,8 @@ func (c *Configuration) isZero() bool {
 	case len(c.ExtraFlanneldArgs) > 0:
 		return false
 	case len(c.ExtraFlanneldEnv) > 0:
+		return false
+	case len(c.ExtraConfigFiles) > 0:
 		return false
 	}
 	return true

--- a/pkg/k8sinit/schema_test.go
+++ b/pkg/k8sinit/schema_test.go
@@ -72,6 +72,9 @@ func TestParse(t *testing.T) {
 						{Name: "core", URL: "https://github.com/canonical/microk8s-core-addons"},
 						{Name: "community", URL: "/snap/microk8s/current/addons/community", Reference: "1.26"},
 					},
+					ExtraConfigFiles: map[string]string{
+						"flannel-network-mgr-config": `{"Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}` + "\n",
+					},
 				}},
 			},
 		},

--- a/pkg/k8sinit/schema_test.go
+++ b/pkg/k8sinit/schema_test.go
@@ -76,6 +76,10 @@ func TestParse(t *testing.T) {
 						"flannel-network-mgr-config": `{"Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}` + "\n",
 					},
 					PersistentClusterToken: "my-token",
+					Join: k8sinit.JoinConfiguration{
+						URL:    "10.0.0.10:25000/my-token/hash",
+						Worker: true,
+					},
 				}},
 			},
 		},

--- a/pkg/k8sinit/schema_test.go
+++ b/pkg/k8sinit/schema_test.go
@@ -75,6 +75,7 @@ func TestParse(t *testing.T) {
 					ExtraConfigFiles: map[string]string{
 						"flannel-network-mgr-config": `{"Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}` + "\n",
 					},
+					PersistentClusterToken: "my-token",
 				}},
 			},
 		},

--- a/pkg/k8sinit/testdata/schema/full.yaml
+++ b/pkg/k8sinit/testdata/schema/full.yaml
@@ -44,3 +44,6 @@ addonRepositories:
     reference: 1.26
 containerdRegistryConfigs:
   docker.io: server = "http://my.proxy:5000"
+join:
+  url: 10.0.0.10:25000/my-token/hash
+  worker: true

--- a/pkg/k8sinit/testdata/schema/full.yaml
+++ b/pkg/k8sinit/testdata/schema/full.yaml
@@ -26,6 +26,9 @@ extraDqliteArgs:
 extraDqliteEnv:
   LIBRAFT_TRACE: "1"
   LIBDQLITE_TRACE: "1"
+extraConfigFiles:
+  flannel-network-mgr-config: |
+    {"Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}
 addons:
   - name: dns
   - name: mayastor

--- a/pkg/k8sinit/testdata/schema/full.yaml
+++ b/pkg/k8sinit/testdata/schema/full.yaml
@@ -1,5 +1,6 @@
 ---
 version: 0.1.0
+persistentClusterToken: my-token
 extraSANs:
   - 10.10.10.10
   - microk8s.example.com

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -103,4 +103,7 @@ type Snap interface {
 
 	// AddAddonsRepository configures an addons repository on the local node, similar to running the 'microk8s addons repo add' command.
 	AddAddonsRepository(ctx context.Context, name, url, reference string, force bool) error
+
+	// JoinCluster joins the local node to an existing MicroK8s cluster as a control-plane or worker node.
+	JoinCluster(ctx context.Context, url string, worker bool) error
 }

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -72,6 +72,8 @@ type Snap interface {
 	// Self callback tokens may be consumed multiple times.
 	ConsumeSelfCallbackToken(token string) bool
 
+	// AddPersistentClusterToken adds a new persistent token that can be used to authenticate join requests.
+	AddPersistentClusterToken(token string) error
 	// AddCertificateRequestToken adds a new token that can be used to authenticate certificate signing requests.
 	AddCertificateRequestToken(token string) error
 	// AddCallbackToken adds a new token that can be used to authenticate requests to a remote cluster agent endpoint.

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -55,6 +55,7 @@ type Snap struct {
 	CertificateRequestTokens []string
 	SelfCallbackTokens       []string
 
+	AddPersistentClusterTokenCalledWith  []string
 	AddCertificateRequestTokenCalledWith []string
 	AddCallbackTokenCalledWith           []string // "{clusterAgentEndpoint} {token}"
 
@@ -234,6 +235,16 @@ func (s *Snap) ConsumeCertificateRequestToken(token string) bool {
 // ConsumeSelfCallbackToken is a mock implementation for the snap.Snap interface.
 func (s *Snap) ConsumeSelfCallbackToken(token string) bool {
 	return contains(s.SelfCallbackTokens, token)
+}
+
+// AddPersistentClusterToken is a mock implementation for the snap.Snap interface.
+func (s *Snap) AddPersistentClusterToken(token string) error {
+	if s.AddPersistentClusterTokenCalledWith == nil {
+		s.AddPersistentClusterTokenCalledWith = make([]string, 0, 1)
+	}
+
+	s.AddPersistentClusterTokenCalledWith = append(s.AddPersistentClusterTokenCalledWith, token)
+	return nil
 }
 
 // AddCertificateRequestToken is a mock implementation for the snap.Snap interface.

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -17,6 +17,12 @@ type AddonRepository struct {
 	Force     bool
 }
 
+// JoinClusterCall is a mock for the join cluster call.
+type JoinClusterCall struct {
+	URL    string
+	Worker bool
+}
+
 // Snap is a generic mock for the snap.Snap interface.
 type Snap struct {
 	GroupName string
@@ -76,6 +82,8 @@ type Snap struct {
 	ContainerdRegistryConfigs map[string]string // map registry name to hosts.toml contents
 
 	AddonRepositories map[string]AddonRepository
+
+	JoinClusterCalledWith []JoinClusterCall
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.
@@ -215,19 +223,12 @@ func contains(list []string, item string) bool {
 
 // ConsumeClusterToken is a mock implementation for the snap.Snap interface.
 func (s *Snap) ConsumeClusterToken(token string) bool {
-	if s.ConsumeClusterTokenCalledWith == nil {
-		s.ConsumeClusterTokenCalledWith = make([]string, 0, 1)
-	}
 	s.ConsumeClusterTokenCalledWith = append(s.ConsumeClusterTokenCalledWith, token)
 	return contains(s.ClusterTokens, token)
 }
 
 // ConsumeCertificateRequestToken is a mock implementation for the snap.Snap interface.
 func (s *Snap) ConsumeCertificateRequestToken(token string) bool {
-	if s.ConsumeCertificateRequestTokenCalledWith == nil {
-		s.ConsumeCertificateRequestTokenCalledWith = make([]string, 0, 1)
-	}
-
 	s.ConsumeCertificateRequestTokenCalledWith = append(s.ConsumeCertificateRequestTokenCalledWith, token)
 	return contains(s.CertificateRequestTokens, token)
 }
@@ -239,41 +240,19 @@ func (s *Snap) ConsumeSelfCallbackToken(token string) bool {
 
 // AddPersistentClusterToken is a mock implementation for the snap.Snap interface.
 func (s *Snap) AddPersistentClusterToken(token string) error {
-	if s.AddPersistentClusterTokenCalledWith == nil {
-		s.AddPersistentClusterTokenCalledWith = make([]string, 0, 1)
-	}
-
 	s.AddPersistentClusterTokenCalledWith = append(s.AddPersistentClusterTokenCalledWith, token)
 	return nil
 }
 
 // AddCertificateRequestToken is a mock implementation for the snap.Snap interface.
 func (s *Snap) AddCertificateRequestToken(token string) error {
-	if s.AddCertificateRequestTokenCalledWith == nil {
-		s.AddCertificateRequestTokenCalledWith = make([]string, 0, 1)
-	}
-
 	s.AddCertificateRequestTokenCalledWith = append(s.AddCertificateRequestTokenCalledWith, token)
 	return nil
 }
 
 // AddCallbackToken is a mock implementation for the snap.Snap interface.
 func (s *Snap) AddCallbackToken(clusterAgentEndpoint string, token string) error {
-	if s.AddCallbackTokenCalledWith == nil {
-		s.AddCallbackTokenCalledWith = make([]string, 0, 1)
-	}
-
 	s.AddCallbackTokenCalledWith = append(s.AddCallbackTokenCalledWith, fmt.Sprintf("%s %s", clusterAgentEndpoint, token))
-	return nil
-}
-
-// RemoveClusterToken is a mock implementation for the snap.Snap interface.
-func (s *Snap) RemoveClusterToken(token string) error {
-	if s.ConsumeClusterTokenCalledWith == nil {
-		s.ConsumeClusterTokenCalledWith = make([]string, 0, 1)
-	}
-
-	s.ConsumeClusterTokenCalledWith = append(s.ConsumeClusterTokenCalledWith, token)
 	return nil
 }
 
@@ -307,27 +286,18 @@ func (s *Snap) GetKnownToken(username string) (string, error) {
 
 // RunUpgrade is a mock implementation for the snap.Snap interface.
 func (s *Snap) RunUpgrade(ctx context.Context, upgrade string, phase string) error {
-	if s.RunUpgradeCalledWith == nil {
-		s.RunUpgradeCalledWith = make([]string, 0, 1)
-	}
 	s.RunUpgradeCalledWith = append(s.RunUpgradeCalledWith, fmt.Sprintf("%s %s", upgrade, phase))
 	return nil
 }
 
 // SignCertificate is a mock implementation for the snap.Snap interface.
 func (s *Snap) SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, error) {
-	if s.SignCertificateCalledWith == nil {
-		s.SignCertificateCalledWith = make([]string, 0, 1)
-	}
 	s.SignCertificateCalledWith = append(s.SignCertificateCalledWith, string(csrPEM))
 	return []byte(s.SignedCertificate), nil
 }
 
 // ImportImage is a mock implementation for the snap.Snap interface.
 func (s *Snap) ImportImage(ctx context.Context, reader io.Reader) error {
-	if s.ImportImageCalledWith == nil {
-		s.ImportImageCalledWith = make([]string, 0, 1)
-	}
 	b, _ := io.ReadAll(reader)
 	s.ImportImageCalledWith = append(s.ImportImageCalledWith, string(b))
 	return nil
@@ -361,6 +331,12 @@ func (s *Snap) AddAddonsRepository(ctx context.Context, name, url, reference str
 		Reference: reference,
 		Force:     force,
 	}
+	return nil
+}
+
+// JoinCluster is a mock implementation for the snap.Snap interface.
+func (s *Snap) JoinCluster(ctx context.Context, url string, worker bool) error {
+	s.JoinClusterCalledWith = append(s.JoinClusterCalledWith, JoinClusterCall{url, worker})
 	return nil
 }
 

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -396,4 +396,15 @@ func (s *snap) AddAddonsRepository(ctx context.Context, name, url, reference str
 	return nil
 }
 
+func (s *snap) JoinCluster(ctx context.Context, url string, worker bool) error {
+	cmd := []string{filepath.Join(s.snapPath("microk8s-join.wrapper")), url}
+	if worker {
+		cmd = append(cmd, "--worker")
+	}
+	if err := s.runCommand(ctx, cmd...); err != nil {
+		return fmt.Errorf("failed to execute microk8s join command: %w", err)
+	}
+	return nil
+}
+
 var _ Snap = &snap{}

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -221,6 +221,9 @@ func (s *snap) WriteServiceArguments(serviceName string, arguments []byte) error
 func (s *snap) ConsumeClusterToken(token string) bool {
 	s.clusterTokensMu.Lock()
 	defer s.clusterTokensMu.Unlock()
+	if isValid, _ := util.IsValidToken(token, s.snapDataPath("credentials", "persistent-cluster-tokens.txt")); isValid {
+		return true
+	}
 	clusterTokensFile := s.snapDataPath("credentials", "cluster-tokens.txt")
 	isValid, hasTTL := util.IsValidToken(token, clusterTokensFile)
 	if isValid && !hasTTL {
@@ -247,6 +250,12 @@ func (s *snap) ConsumeCertificateRequestToken(token string) bool {
 func (s *snap) ConsumeSelfCallbackToken(token string) bool {
 	valid, _ := util.IsValidToken(token, s.snapDataPath("credentials", "callback-token.txt"))
 	return valid
+}
+
+func (s *snap) AddPersistentClusterToken(token string) error {
+	s.certTokensMu.Lock()
+	defer s.certTokensMu.Unlock()
+	return util.AppendToken(token, s.snapDataPath("credentials", "persistent-cluster-tokens.txt"), s.GetGroupName())
 }
 
 func (s *snap) AddCertificateRequestToken(token string) error {

--- a/pkg/snap/snap_join_test.go
+++ b/pkg/snap/snap_join_test.go
@@ -1,0 +1,45 @@
+package snap_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
+	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
+	. "github.com/onsi/gomega"
+)
+
+func TestJoinCluster(t *testing.T) {
+	t.Run("PropagateError", func(t *testing.T) {
+		g := NewWithT(t)
+		runner := &utiltest.MockRunner{}
+		s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(runner.Run))
+		runner.Err = fmt.Errorf("some error")
+
+		err := s.JoinCluster(context.Background(), "some-url", false)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(errors.Is(err, runner.Err)).To(BeTrue())
+	})
+
+	t.Run("ControlPlane", func(t *testing.T) {
+		g := NewWithT(t)
+		runner := &utiltest.MockRunner{}
+		s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(runner.Run))
+
+		err := s.JoinCluster(context.Background(), "10.10.10.10:25000/token/hash", false)
+		g.Expect(err).To(BeNil())
+		g.Expect(runner.CalledWithCommand).To(ConsistOf("testdata/microk8s-join.wrapper 10.10.10.10:25000/token/hash"))
+	})
+
+	t.Run("Worker", func(t *testing.T) {
+		g := NewWithT(t)
+		runner := &utiltest.MockRunner{}
+		s := snap.NewSnap("testdata", "testdata", snap.WithCommandRunner(runner.Run))
+
+		err := s.JoinCluster(context.Background(), "10.10.10.10:25000/token/hash", true)
+		g.Expect(err).To(BeNil())
+		g.Expect(runner.CalledWithCommand).To(ConsistOf("testdata/microk8s-join.wrapper 10.10.10.10:25000/token/hash --worker"))
+	})
+}


### PR DESCRIPTION
### Summary

Add launch configurations for:

- extra config files (needed for setups like resource encryption, audit policy, flannel network management, etc)
- cluster tokens using launch configurations
- join cluster using launch configurations

With this change, cluster agent is responsible for applying all launch configurations, as it brings the following improvements:
  - launch configurations do not apply on worker nodes otherwise, since apiservice kicker is only running on control plane nodes
  - no extra subprocesses are spawned to check for new configs
 
Requires changes to the microk8s repo as well, see linked PR