### PR TITLE
Backport fixes to 1.26 branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18"
+          go-version: "1.19"
 
       - name: go fmt
         run: make go.fmt
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18"
+          go-version: "1.19"
 
       - name: Run tests
         run: make go.test

--- a/cmd/cluster-agent.go
+++ b/cmd/cluster-agent.go
@@ -43,6 +43,7 @@ lifecycle of a MicroK8s cluster.`,
 		apiv2 := &v2.API{
 			Snap:                    s,
 			LookupIP:                net.LookupIP,
+			InterfaceAddrs:          net.InterfaceAddrs,
 			ListControlPlaneNodeIPs: snaputil.ListControlPlaneNodeIPs,
 		}
 		srv := server.NewServer(time.Duration(timeout)*time.Second, enableMetrics, apiv1, apiv2)

--- a/cmd/cluster-agent.go
+++ b/cmd/cluster-agent.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"log"
 	"net"
 	"net/http"
@@ -21,6 +22,7 @@ var (
 	certfile      string
 	timeout       int
 	enableMetrics bool
+	minTLSVersion string
 )
 
 // clusterAgentCmd represents the base command when called without any subcommands
@@ -46,9 +48,35 @@ lifecycle of a MicroK8s cluster.`,
 			InterfaceAddrs:          net.InterfaceAddrs,
 			ListControlPlaneNodeIPs: snaputil.ListControlPlaneNodeIPs,
 		}
-		srv := server.NewServer(time.Duration(timeout)*time.Second, enableMetrics, apiv1, apiv2)
+		mux := server.NewServeMux(time.Duration(timeout)*time.Second, enableMetrics, apiv1, apiv2)
+		srv := &http.Server{
+			Addr:    bind,
+			Handler: mux,
+		}
+
+		switch minTLSVersion {
+		case "tls10":
+			srv.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS10,
+			}
+		case "tls11":
+			srv.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS11,
+			}
+		case "", "tls12":
+			srv.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+		case "tls13":
+			srv.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS13,
+			}
+		default:
+			log.Printf("ERROR: Unsupported TLS version %v. Supported values: tls10, tls11, tls12, tls13.", minTLSVersion)
+		}
+
 		log.Printf("Starting cluster agent on https://%s\n", bind)
-		if err := http.ListenAndServeTLS(bind, certfile, keyfile, srv); err != nil {
+		if err := srv.ListenAndServeTLS(certfile, keyfile); err != nil {
 			log.Fatalf("Failed to listen: %s", err)
 		}
 	},
@@ -60,6 +88,7 @@ func init() {
 	clusterAgentCmd.Flags().StringVar(&certfile, "certfile", "", "Certificate for serving TLS")
 	clusterAgentCmd.Flags().IntVar(&timeout, "timeout", 240, "Default request timeout (in seconds)")
 	clusterAgentCmd.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics endpoint")
+	clusterAgentCmd.Flags().StringVar(&minTLSVersion, "min-tls-version", "tls12", "Minimum TLS version required (tls10|tls11|tls12|tls13). Default is tls12")
 
 	rootCmd.AddCommand(clusterAgentCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/canonical/microk8s-cluster-agent
 
-go 1.18
+go 1.19
 
 require (
 	github.com/fsnotify/fsnotify v1.5.4
+	github.com/onsi/gomega v1.10.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.3.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -38,6 +39,7 @@ require (
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/api/v1/configure.go
+++ b/pkg/api/v1/configure.go
@@ -47,7 +47,7 @@ func (a *API) Configure(ctx context.Context, req ConfigureRequest) error {
 		return fmt.Errorf("invalid token")
 	}
 	for _, service := range req.ConfigureServices {
-		if err := snaputil.UpdateServiceArguments(a.Snap, service.Name, service.UpdateArguments, service.RemoveArguments); err != nil {
+		if _, err := snaputil.UpdateServiceArguments(a.Snap, service.Name, service.UpdateArguments, service.RemoveArguments); err != nil {
 			return fmt.Errorf("failed to update arguments of service %q: %w", service.Name, err)
 		}
 		if service.Restart {

--- a/pkg/api/v2/api.go
+++ b/pkg/api/v2/api.go
@@ -19,6 +19,9 @@ type API struct {
 	// LookupIP is net.LookupIP.
 	LookupIP func(string) ([]net.IP, error)
 
+	// InterfaceAddrs is net.InterfaceAddrs.
+	InterfaceAddrs func() ([]net.Addr, error)
+
 	// dqliteMu protects changes involving the dqlite service.
 	dqliteMu sync.Mutex
 

--- a/pkg/api/v2/api_util.go
+++ b/pkg/api/v2/api_util.go
@@ -1,0 +1,66 @@
+package v2
+
+import (
+	"fmt"
+	"log"
+	"net"
+)
+
+// findMatchingBindAddress attempts to find the bind address for dqlite from the 'host:port' of the join request.
+// in case of system errors, the request host is returned, to preserve backwards-compatibility.
+func (a *API) findMatchingBindAddress(hostPort string) (string, error) {
+	hostIP, _, _ := net.SplitHostPort(hostPort)
+
+	hostNetIP := net.ParseIP(hostIP)
+	if hostNetIP == nil {
+		log.Printf("[WARNING] failed to parse IP address %v", hostIP)
+		log.Printf("[WARNING] will attempt to use %v as dqlite bind address", hostIP)
+		return hostIP, nil
+	}
+
+	addrs, err := a.InterfaceAddrs()
+	if err != nil {
+		log.Printf("[WARNING] failed to retrieve host addresses: %v", err)
+		log.Printf("[WARNING] will attempt to use %v as dqlite bind address", hostIP)
+		return hostIP, nil
+	}
+
+	var (
+		isVirtualIP         bool
+		matchingInterfaceIP net.IP
+	)
+
+nextAddr:
+	for _, addr := range addrs {
+		ip, subnet, err := net.ParseCIDR(addr.String())
+		if err != nil || subnet == nil {
+			log.Printf("[WARNING] failed to parse address %v: %v", addr.String(), err)
+			continue nextAddr
+		}
+
+		ones, bits := subnet.Mask.Size()
+		subnetHostBits := bits - ones
+		if ip.Equal(hostNetIP) {
+			// virtual IPs are /32 IPv4 or /128 IPv6
+			isVirtualIP = subnetHostBits == 0
+			if !isVirtualIP {
+				return hostIP, nil
+			}
+		} else if subnet.Contains(hostNetIP) && subnetHostBits > 0 {
+			// we found the IP address of the interface
+			matchingInterfaceIP = ip
+		}
+	}
+
+	if isVirtualIP {
+		if matchingInterfaceIP != nil {
+			return matchingInterfaceIP.String(), nil
+		}
+
+		// hostIP is most likely a virtual IP, but we were not able to find the matching IP address. return the IP address to maintain backwards-compatibility.
+		return hostIP, nil
+	}
+
+	// no host address matched
+	return "", fmt.Errorf("address %v was not found in any host interface. refuse to update dqlite bind address to %v as it would break the cluster", hostIP, hostIP)
+}

--- a/pkg/api/v2/api_util_test.go
+++ b/pkg/api/v2/api_util_test.go
@@ -1,0 +1,89 @@
+package v2
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
+	. "github.com/onsi/gomega"
+)
+
+func TestStdlibPreconditions(t *testing.T) {
+	g := NewWithT(t)
+	addrs, err := net.InterfaceAddrs()
+	g.Expect(err).To(BeNil(), "net.InterfaceAddrs() must not fail")
+
+	for _, addr := range addrs {
+		ip, subnet, err := net.ParseCIDR(addr.String())
+		g.Expect(err).To(BeNil(), "net.ParseCIDR() must not fail for %v", addr.String())
+		g.Expect(ip).ToNot(BeNil(), "Address for %v must not be nil", addr.String())
+		g.Expect(subnet).ToNot(BeNil(), "Subnet for %v must not be nil", addr.String())
+	}
+}
+
+func TestFindMatchingBindAddress(t *testing.T) {
+	t.Run("FallbackOnFailure", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var interfaceAddrsCalled bool
+		a := API{
+			InterfaceAddrs: func() ([]net.Addr, error) {
+				interfaceAddrsCalled = true
+				return nil, fmt.Errorf("some error")
+			},
+		}
+
+		addr, err := a.findMatchingBindAddress("10.0.0.10:25000")
+		g.Expect(interfaceAddrsCalled).To(BeTrue())
+		g.Expect(err).To(BeNil())
+		g.Expect(addr).To(Equal("10.0.0.10"))
+	})
+
+	t.Run("FailOnMissing", func(t *testing.T) {
+		g := NewWithT(t)
+		a := API{InterfaceAddrs: net.InterfaceAddrs}
+
+		// 1.1.1.1 should almost never be a host address, this test will fail otherwise
+		addr, err := a.findMatchingBindAddress("1.1.1.1:25000")
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(addr).To(BeEmpty())
+	})
+
+	t.Run("HandleVirtualIP", func(t *testing.T) {
+		a := API{
+			InterfaceAddrs: func() ([]net.Addr, error) {
+				return []net.Addr{
+					&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
+					&utiltest.MockCIDR{CIDR: "10.0.0.10/16"},
+					&utiltest.MockCIDR{CIDR: "10.10.0.10/16"},
+					&utiltest.MockCIDR{CIDR: "10.0.100.100/32"},
+					&utiltest.MockCIDR{CIDR: "192.168.100.100/32"},
+				}, nil
+			},
+		}
+		t.Run("UseInterfaceIP", func(t *testing.T) {
+			g := NewWithT(t)
+
+			addr, err := a.findMatchingBindAddress("10.0.0.10:25000")
+			g.Expect(err).To(BeNil())
+			g.Expect(addr).To(Equal("10.0.0.10"))
+		})
+
+		t.Run("UseVirtualIP", func(t *testing.T) {
+			g := NewWithT(t)
+
+			addr, err := a.findMatchingBindAddress("10.0.100.100:25000")
+			g.Expect(err).To(BeNil())
+			g.Expect(addr).To(Equal("10.0.0.10"))
+		})
+
+		t.Run("FallbackToVirtualIPIfSubnetNotFound", func(t *testing.T) {
+			g := NewWithT(t)
+
+			addr, err := a.findMatchingBindAddress("192.168.100.100:25000")
+			g.Expect(err).To(BeNil())
+			g.Expect(addr).To(Equal("192.168.100.100"))
+		})
+	})
+}

--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -107,7 +107,9 @@ func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, er
 
 	// Check node is not in cluster already.
 	a.dqliteMu.Lock()
-	dqliteCluster, err := snaputil.GetDqliteCluster(a.Snap)
+	dqliteCluster, err := snaputil.WaitForDqliteCluster(ctx, a.Snap, func(c snaputil.DqliteCluster) (bool, error) {
+		return len(c) >= 1, nil
+	})
 	if err != nil {
 		a.dqliteMu.Unlock()
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to retrieve dqlite cluster nodes: %w", err)

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -10,6 +10,7 @@ import (
 
 	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
+	utiltest "github.com/canonical/microk8s-cluster-agent/pkg/util/test"
 )
 
 // TestJoin tests responses when joining control plane and worker nodes in an existing cluster.
@@ -56,6 +57,12 @@ Role: 0
 				"test-control-plane": {{10, 10, 10, 13}},
 				"test-worker":        {{10, 10, 10, 12}},
 			}[hostname], nil
+		},
+		InterfaceAddrs: func() ([]net.Addr, error) {
+			return []net.Addr{
+				&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
+				&utiltest.MockCIDR{CIDR: "10.0.0.10/16"},
+			}, nil
 		},
 		ListControlPlaneNodeIPs: mockListControlPlaneNodes("10.0.0.1", "10.0.0.2"),
 	}
@@ -203,6 +210,12 @@ Role: 0
 		Snap: s,
 		LookupIP: func(hostname string) ([]net.IP, error) {
 			return []net.IP{{10, 10, 10, 13}}, nil
+		},
+		InterfaceAddrs: func() ([]net.Addr, error) {
+			return []net.Addr{
+				&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
+				&utiltest.MockCIDR{CIDR: "10.10.10.10/16"},
+			}, nil
 		},
 	}
 

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -3,7 +3,7 @@ package httputil
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"unicode"
@@ -11,7 +11,7 @@ import (
 
 // UnmarshalJSON unmarshals JSON data from the HTTP request body.
 func UnmarshalJSON(r *http.Request, v interface{}) error {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read request body: %w", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,6 +26,16 @@ func NewServer(timeout time.Duration, enableMetrics bool, apiv1 *v1.API, apiv2 *
 		httputil.Error(w, http.StatusNotFound, fmt.Errorf("not found"))
 	}))
 
+	// GET /health
+	server.HandleFunc("/health", withMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		httputil.Response(w, map[string]string{"status": "OK"})
+	}))
+
 	// Prometheus metrics
 	if enableMetrics {
 		server.HandleFunc("/metrics", withMiddleware(promhttp.Handler().ServeHTTP))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,8 +12,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// NewServer creates a new *http.ServeMux and registers the MicroK8s cluster agent API endpoints.
-func NewServer(timeout time.Duration, enableMetrics bool, apiv1 *v1.API, apiv2 *v2.API) *http.ServeMux {
+// NewServeMux creates a new *http.ServeMux and registers the MicroK8s cluster agent API endpoints.
+func NewServeMux(timeout time.Duration, enableMetrics bool, apiv1 *v1.API, apiv2 *v2.API) *http.ServeMux {
 	server := http.NewServeMux()
 
 	withMiddleware := func(f http.HandlerFunc) http.HandlerFunc {

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	"github.com/canonical/microk8s-cluster-agent/pkg/util"
@@ -305,7 +304,7 @@ func (s *Snap) ImportImage(ctx context.Context, reader io.Reader) error {
 	if s.ImportImageCalledWith == nil {
 		s.ImportImageCalledWith = make([]string, 0, 1)
 	}
-	b, _ := ioutil.ReadAll(reader)
+	b, _ := io.ReadAll(reader)
 	s.ImportImageCalledWith = append(s.ImportImageCalledWith, string(b))
 	return nil
 }

--- a/pkg/snap/util/services.go
+++ b/pkg/snap/util/services.go
@@ -1,7 +1,9 @@
 package snaputil
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
@@ -61,7 +63,7 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 	}
 
 	arguments, err := s.ReadServiceArguments(serviceName)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return false, fmt.Errorf("failed to read arguments of service %s: %w", serviceName, err)
 	}
 

--- a/pkg/snap/util/services.go
+++ b/pkg/snap/util/services.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
+	"github.com/canonical/microk8s-cluster-agent/pkg/util"
 )
 
 // GetServiceArgument retrieves the value of a specific argument from the $SNAP_DATA/args/$service file.
@@ -18,13 +19,13 @@ func GetServiceArgument(s snap.Snap, serviceName string, argument string) string
 
 	for _, line := range strings.Split(arguments, "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, argument) {
+		// ignore empty lines
+		if line == "" {
 			continue
 		}
-		// parse "--argument value" and "--argument=value" variants
-		line = line[strings.LastIndex(line, " ")+1:]
-		line = line[strings.LastIndex(line, "=")+1:]
-		return line
+		if key, value := util.ParseArgumentLine(line); key == argument {
+			return value
+		}
 	}
 	return ""
 }
@@ -33,7 +34,8 @@ func GetServiceArgument(s snap.Snap, serviceName string, argument string) string
 // UpdateServiceArguments is a no-op if updateList and delete are empty.
 // updateList is a map of key-value pairs. It will replace the argument with the new value (or just append).
 // delete is a list of arguments to remove completely. The argument is removed if present.
-func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[string]string, delete []string) error {
+// Returns a boolean whether any of the arguments were changed, as well as any errors that may have occured.
+func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[string]string, delete []string) (bool, error) {
 	if updateList == nil {
 		updateList = []map[string]string{}
 	}
@@ -43,7 +45,7 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 
 	// If no updates are requested, exit early
 	if len(updateList) == 0 && len(delete) == 0 {
-		return nil
+		return false, nil
 	}
 
 	deleteMap := make(map[string]struct{}, len(delete))
@@ -60,9 +62,10 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 
 	arguments, err := s.ReadServiceArguments(serviceName)
 	if err != nil {
-		return fmt.Errorf("failed to read arguments of service %s: %w", serviceName, err)
+		return false, fmt.Errorf("failed to read arguments of service %s: %w", serviceName, err)
 	}
 
+	changed := false
 	existingArguments := make(map[string]struct{}, len(arguments))
 	newArguments := make([]string, 0, len(arguments))
 	for _, line := range strings.Split(arguments, "\n") {
@@ -71,15 +74,17 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 		if line == "" {
 			continue
 		}
-		// handle "--argument value" and "--argument=value" variants
-		key := strings.SplitN(line, " ", 2)[0]
-		key = strings.SplitN(key, "=", 2)[0]
+		key, oldValue := util.ParseArgumentLine(line)
 		existingArguments[key] = struct{}{}
 		if newValue, ok := updateMap[key]; ok {
 			// update argument with new value
 			newArguments = append(newArguments, fmt.Sprintf("%s=%s", key, newValue))
+			if oldValue != newValue {
+				changed = true
+			}
 		} else if _, ok := deleteMap[key]; ok {
 			// remove argument
+			changed = true
 			continue
 		} else {
 			// no change
@@ -89,12 +94,13 @@ func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[st
 
 	for key, value := range updateMap {
 		if _, argExists := existingArguments[key]; !argExists {
+			changed = true
 			newArguments = append(newArguments, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
 
 	if err := s.WriteServiceArguments(serviceName, []byte(strings.Join(newArguments, "\n")+"\n")); err != nil {
-		return fmt.Errorf("failed to update arguments for service %s: %q", serviceName, err)
+		return false, fmt.Errorf("failed to update arguments for service %s: %q", serviceName, err)
 	}
-	return nil
+	return changed, nil
 }

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
 )
 
 // FileExists returns true if the specified path exists.
@@ -32,4 +33,23 @@ func ReadFile(path string) (string, error) {
 		return "", fmt.Errorf("failed to read %s: %w", path, err)
 	}
 	return string(b), nil
+}
+
+// ParseArgumentLine parses a command-line argument from a single line.
+// The returned key includes any dash prefixes.
+func ParseArgumentLine(line string) (key string, value string) {
+	line = strings.TrimSpace(line)
+
+	// parse "--argument value" and "--argument=value" variants
+	if parts := strings.Split(line, "="); len(parts) >= 2 {
+		key = parts[0]
+		value = parts[1]
+	} else if parts := strings.Split(line, " "); len(parts) >= 2 {
+		key = parts[0]
+		value = strings.Join(parts[1:], " ")
+	} else {
+		key = line
+	}
+
+	return
 }

--- a/pkg/util/files_test.go
+++ b/pkg/util/files_test.go
@@ -40,3 +40,30 @@ func TestReadFile(t *testing.T) {
 	}
 	os.Remove("testdata/test-read-file")
 }
+
+func TestParseArgumentLine(t *testing.T) {
+	for _, tc := range []struct {
+		line, key, value string
+	}{
+		{line: "--key=value", key: "--key", value: "value"},
+		{line: "--key=value   ", key: "--key", value: "value"},
+		{line: "--key value", key: "--key", value: "value"},
+		{line: "--key value     ", key: "--key", value: "value"},
+		{line: "--key value value", key: "--key", value: "value value"},
+		{line: "--key=value value", key: "--key", value: "value value"},
+		{line: "--key", key: "--key", value: ""},
+		{line: "--key    ", key: "--key", value: ""},
+		{line: "--key=", key: "--key", value: ""},
+		{line: "--key=    ", key: "--key", value: ""},
+	} {
+		t.Run(tc.line, func(t *testing.T) {
+			key, value := util.ParseArgumentLine(tc.line)
+			if key != tc.key {
+				t.Fatalf("Expected key to be %q but it was %q instead", tc.key, key)
+			}
+			if value != tc.value {
+				t.Fatalf("Expected value to be %q but it was %q instead", tc.value, value)
+			}
+		})
+	}
+}

--- a/pkg/util/test/mock_cidr.go
+++ b/pkg/util/test/mock_cidr.go
@@ -1,0 +1,20 @@
+package utiltest
+
+import "net"
+
+// MockCIDR is a mock net.Addr
+type MockCIDR struct {
+	CIDR string
+}
+
+// Network implements net.Addr
+func (v *MockCIDR) Network() string {
+	return ""
+}
+
+// String implements net.Addr
+func (v *MockCIDR) String() string {
+	return v.CIDR
+}
+
+var _ net.Addr = &MockCIDR{}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,16 +1,15 @@
 module github.com/canonical/microk8s-cluster-agent/tools
 
-go 1.18
+go 1.19
 
 require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
-	honnef.co/go/tools v0.3.0-0.dev.0.20220306074811-23e1086441d2
+	honnef.co/go/tools v0.3.3
 )
 
 require (
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
-	golang.org/x/mod v0.5.1 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
-	golang.org/x/tools v0.1.8 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f // indirect
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -6,8 +6,8 @@ golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -17,10 +17,8 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjq
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
-golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f h1:OKYpQQVE3DKSc3r3zHVzq46vq5YH7x8xpR3/k9ixmUg=
+golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-honnef.co/go/tools v0.3.0-0.dev.0.20220306074811-23e1086441d2 h1:utiSabORbG/JeX7MlmKMdmsjwom2+v8zmdb6SoBe4UY=
-honnef.co/go/tools v0.3.0-0.dev.0.20220306074811-23e1086441d2/go.mod h1:dZI0HmIvwDMW8owtLBJxTHoeX48yuF5p5pDy3y73jGU=
+honnef.co/go/tools v0.3.3 h1:oDx7VAwstgpYpb3wv0oxiZlxY+foCpRAwY7Vk6XpAgA=
+honnef.co/go/tools v0.3.3/go.mod h1:jzwdWgg7Jdq75wlfblQxO4neNaFFSvgc1tD5Wv8U0Yw=


### PR DESCRIPTION
Backport fixes to 1.26 branch https://github.com/canonical/microk8s-cluster-agent/pull/14 https://github.com/canonical/microk8s-cluster-agent/pull/26 https://github.com/canonical/microk8s-cluster-agent/pull/23 https://github.com/canonical/microk8s-cluster-agent/pull/25 https://github.com/canonical/microk8s-cluster-agent/pull/26 https://github.com/canonical/microk8s-cluster-agent/pull/26 https://github.com/canonical/microk8s-cluster-agent/pull/30 and update to Go 1.19