### PR TITLE
Do nothing if extraSANs is not set

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ go.lint:
 	cd tools && go run golang.org/x/lint/golint -set_exit_status ../...
 
 go.staticcheck:
-	cd tools && go install honnef.co/go/tools/cmd/staticcheck
+	cd tools && go install honnef.co/go/tools/cmd/staticcheck@2023.1.3
 	$(shell go env GOPATH)/bin/staticcheck ./...
 
 go.test:

--- a/pkg/k8sinit/apply.go
+++ b/pkg/k8sinit/apply.go
@@ -151,8 +151,11 @@ func (s *launcherScope) reconcileServiceArgs(ctx context.Context, configFile str
 	return changed, nil
 }
 
-func (s *launcherScope) reconcileExtraSANs(extraSANs []string) error {
-	csr, err := util.GenerateCSRConf(extraSANs)
+func (s *launcherScope) reconcileExtraSANs(extraSANs *[]string) error {
+	if extraSANs == nil {
+		return nil
+	}
+	csr, err := util.GenerateCSRConf(*extraSANs)
 	if err != nil {
 		return fmt.Errorf("failed to generate csr configuration: %w", err)
 	}

--- a/pkg/k8sinit/schema.go
+++ b/pkg/k8sinit/schema.go
@@ -93,7 +93,7 @@ type Configuration struct {
 	ExtraKubeliteEnv map[string]*string `yaml:"extraKubeliteEnv"`
 
 	// ExtraSANs are a list of extra Subject Alternate Names to add to the local API server.
-	ExtraSANs []string `yaml:"extraSANs"`
+	ExtraSANs *[]string `yaml:"extraSANs"`
 
 	// ContainerdRegistryConfigs is containerd hosts.toml configurations to configure registries.
 	ContainerdRegistryConfigs map[string]string `yaml:"containerdRegistryConfigs"`
@@ -244,7 +244,7 @@ func (c *Configuration) isZero() bool {
 		return false
 	case len(c.ExtraKubeliteEnv) > 0:
 		return false
-	case len(c.ExtraSANs) > 0:
+	case c.ExtraSANs != nil && len(*c.ExtraSANs) > 0:
 		return false
 	case len(c.ContainerdRegistryConfigs) > 0:
 		return false

--- a/pkg/k8sinit/schema_test.go
+++ b/pkg/k8sinit/schema_test.go
@@ -24,7 +24,7 @@ func TestParse(t *testing.T) {
 			expectConfiguration: k8sinit.MultiPartConfiguration{
 				Parts: []*k8sinit.Configuration{{
 					Version: "0.1.0",
-					ExtraSANs: []string{
+					ExtraSANs: &[]string{
 						"10.10.10.10",
 						"microk8s.example.com",
 					},
@@ -106,6 +106,18 @@ func TestParse(t *testing.T) {
 			expectConfiguration: k8sinit.MultiPartConfiguration{
 				Parts: []*k8sinit.Configuration{{
 					Version: "0.1.0",
+				}},
+			},
+		},
+		{
+			name: "extra-sans.yaml",
+			expectConfiguration: k8sinit.MultiPartConfiguration{
+				Parts: []*k8sinit.Configuration{{
+					Version:   "0.1.0",
+					ExtraSANs: nil,
+				}, {
+					Version:   "0.1.0",
+					ExtraSANs: &[]string{},
 				}},
 			},
 		},

--- a/pkg/k8sinit/testdata/schema/extra-sans.yaml
+++ b/pkg/k8sinit/testdata/schema/extra-sans.yaml
@@ -1,0 +1,5 @@
+---
+version: 0.1.0
+---
+version: 0.1.0
+extraSANs: []


### PR DESCRIPTION
### Summary

If `extraSANs` is not set in the launch configuration, do not do anything.

### Description

The change is best described with the following table:

| yaml | extraSANs | old behaviour | new behaviour |
| -|-|-|-|
| (unset) | `nil` | update certificates without any extra SANs (bug) | do nothing |
| `extraSANs: []` | `[]string{}` | update certificates without any extra SANs | update certificates without any extra SANs |
| `extraSANs: [v1, v2]` | `[]string{"v1", "v2"}` | update certificates with extra SANs | update certificates with extra SANs |

### Implementation

We change the `ExtraSANs` field in the launch configuration to be a pointer, and thus `nil` if the field is not set. We also want to separate the missing value (`nil`) from the zero value (`[]string{}`).

Added a test to prevent future regressions