### PR TITLE
Do not require hostname resolution if InternalIP is preferred

### DIFF
--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -103,7 +103,8 @@ func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, er
 	}
 
 	// Check that hostname resolves to the expected IP address
-	if util.GetRemoteHost(a.LookupIP, req.RemoteHostName, req.RemoteAddress) != req.RemoteHostName {
+	// The check is only required if 'Hostname' is preferred over 'InternalIP' to communicate with the Kubelet
+	if !a.kubeAPIServerPrefersInternalIPForKubelet() && util.GetRemoteHost(a.LookupIP, req.RemoteHostName, req.RemoteAddress) != req.RemoteHostName {
 		return nil, http.StatusBadRequest, fmt.Errorf("the hostname (%s) of the joining node does not resolve to the IP %q. Refusing join", req.RemoteHostName, remoteIP)
 	}
 


### PR DESCRIPTION
# Summary

We require hostname resolution when joining a node in an existing MicroK8s cluster. This is not required if the kube-apiserver prefers `InternalIP` instead of `Hostname` for talking to the kubelets.

# Changes

- Check kube-apiserver `--kubelet-preferred-address-types` to see if `InternalIP` is preferred over `Hostname`. If yes, skip the hostname checking
- Unit tests
- Update join_v2 tests to use gomega 
