### PR TITLE
Add IPv* resolution for CNI patching

### DIFF
--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -47,7 +47,11 @@ Role: 0
 		},
 		ClusterTokens:     []string{"worker-token", "control-plane-token"},
 		SelfCallbackToken: "callback-token",
-		CNIYaml:           `some random content. "first-found"`,
+		CNIYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
 		KnownTokens: map[string]string{
 			"admin": "admin-token-123",
 		},
@@ -178,7 +182,11 @@ Role: 0
 		},
 		ClusterTokens:     []string{"control-plane-token"},
 		SelfCallbackToken: "callback-token",
-		CNIYaml:           `some random content. "first-found"`,
+		CNIYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
 		KnownTokens: map[string]string{
 			"admin": "admin-token-123",
 		},

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -16,6 +16,11 @@ import (
 
 // TestJoin tests responses when joining control plane and worker nodes in an existing cluster.
 func TestJoin(t *testing.T) {
+	cni := `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`
 	s := &mock.Snap{
 		DqliteLock: true,
 		DqliteCert: "DQLITE CERTIFICATE DATA",
@@ -47,11 +52,7 @@ Role: 0
 		},
 		ClusterTokens:     []string{"worker-token", "control-plane-token"},
 		SelfCallbackToken: "callback-token",
-		CNIYaml: `
-- name: IP_AUTODETECTION_METHOD
-  value: "first-found"
-- name: IP6_AUTODETECTION_METHOD
-  value: "first-found"`,
+		CNIYaml:           cni,
 		KnownTokens: map[string]string{
 			"admin": "admin-token-123",
 		},
@@ -120,6 +121,7 @@ Role: 0
 		// Reset
 		s.ConsumeClusterTokenCalledWith = nil
 		s.ApplyCNICalled = nil
+		s.CNIYaml = cni
 		s.CreateNoCertsReissueLockCalledWith = nil
 
 		resp, _, err := apiv2.Join(context.Background(), v2.JoinRequest{

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -274,7 +274,11 @@ Role: 0`,
 		},
 		ClusterTokens:     []string{"control-plane-token"},
 		SelfCallbackToken: "callback-token",
-		CNIYaml:           `some random content. "first-found"`,
+		CNIYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
 		KnownTokens: map[string]string{
 			"admin": "admin-token-123",
 		},

--- a/pkg/snap/util/calico.go
+++ b/pkg/snap/util/calico.go
@@ -47,10 +47,11 @@ func MaybePatchCalicoAutoDetectionMethod(ctx context.Context, s snap.Snap, canRe
 	}
 
 	newConfig := re.ReplaceAllString(config, fmt.Sprintf("${1}can-reach=%s", canReachHost))
-	if newConfig != config {
-		if err := s.WriteCNIYaml([]byte(newConfig)); err != nil {
-			return fmt.Errorf("failed to update cni configuration: %w", err)
-		}
+	if newConfig == config {
+		return nil
+	}
+	if err := s.WriteCNIYaml([]byte(newConfig)); err != nil {
+		return fmt.Errorf("failed to update cni configuration: %w", err)
 	}
 	if apply {
 		if err := s.ApplyCNI(ctx); err != nil {

--- a/pkg/snap/util/calico.go
+++ b/pkg/snap/util/calico.go
@@ -3,7 +3,6 @@ package snaputil
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"regexp"
 
@@ -39,11 +38,6 @@ func MaybePatchCalicoAutoDetectionMethod(ctx context.Context, s snap.Snap, canRe
 	} else {
 		// Address is in IPv4
 		re = ipAutodetectionMethodRe
-	}
-
-	if re == nil {
-		// NOTE: this should never happen, canReachHost will always be a valid IP address
-		log.Printf("WARNING: %q was not recognised as a valid IPv4 or IPv6 address!", canReachHost)
 	}
 
 	newConfig := re.ReplaceAllString(config, fmt.Sprintf("${1}can-reach=%s", canReachHost))

--- a/pkg/snap/util/calico_test.go
+++ b/pkg/snap/util/calico_test.go
@@ -10,18 +10,39 @@ import (
 
 func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
 	snap := &mock.Snap{
-		CNIYaml: `some contents here and there. value: "first-found"`,
+		CNIYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
 	}
 
 	if err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, "10.10.10.10", true); err != nil {
 		t.Fatalf("Expected no errors but received %q", err)
 	}
 
-	expectedYaml := `some contents here and there. value: "can-reach=10.10.10.10"`
+	expectedYaml := `
+- name: IP_AUTODETECTION_METHOD
+  value: "can-reach=10.10.10.10"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`
 	if snap.CNIYaml != expectedYaml {
 		t.Fatalf("expected CNI yaml to be %q but it was %q", expectedYaml, snap.CNIYaml)
 	}
-	if len(snap.ApplyCNICalled) != 1 {
+
+	if err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", true); err != nil {
+		t.Fatalf("Expected no errors but received %q", err)
+	}
+	expectedYaml = `
+- name: IP_AUTODETECTION_METHOD
+  value: "can-reach=10.10.10.10"
+- name: IP6_AUTODETECTION_METHOD
+  value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`
+	if snap.CNIYaml != expectedYaml {
+		t.Fatalf("expected CNI yaml to be %q but it was %q", expectedYaml, snap.CNIYaml)
+	}
+
+	if len(snap.ApplyCNICalled) != 2 {
 		t.Fatalf("expected ApplyCNI to be called but it was not")
 	}
 }

--- a/pkg/snap/util/calico_test.go
+++ b/pkg/snap/util/calico_test.go
@@ -2,7 +2,6 @@ package snaputil_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
@@ -34,15 +33,63 @@ func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
 			name: "IPv6 Address",
 			cniYaml: `
 - name: IP_AUTODETECTION_METHOD
-  value: value: "first-found"
+  value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
 			canReachHost: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 			expectedYaml: `
 - name: IP_AUTODETECTION_METHOD
-  value: value: "first-found"
+  value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
   value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`,
+		},
+		{
+			name: "IPv4 Address not first-found",
+			cniYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "can-reach=1.1.1.1"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
+			canReachHost: "10.10.10.10",
+			expectedYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "can-reach=1.1.1.1"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
+		},
+		{
+			name: "IPv6 Address not first-found",
+			cniYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`,
+			canReachHost: "2001:0db8:85a3:0000:0000:8a2e:0370:7335",
+			expectedYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`,
+		},
+		{
+			name: "IPv4 Address no autodetection",
+			cniYaml: `
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
+			canReachHost: "1.1.1.1",
+			expectedYaml: `
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`,
+		},
+		{
+			name: "IPv6 Address no autodetection",
+			cniYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"`,
+			canReachHost: "2001:0db8:85a3:0000:0000:8a2e:0370:7335",
+			expectedYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"`,
 		},
 	}
 
@@ -62,44 +109,6 @@ func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
 
 			if len(snap.ApplyCNICalled) != 1 {
 				t.Fatalf("expected ApplyCNI to be called but it was not")
-			}
-		})
-	}
-}
-
-func TestReplaceAfter(t *testing.T) {
-	tests := []struct {
-		input       string
-		after       string
-		target      string
-		replacement string
-		expected    string
-		errExpected bool
-	}{
-		// Test cases
-		{"ipv4 -value=first-found IPV6 -value first-found first-found", "IPV6", "first-found", "can-after=a3a3:a3a3:a3r3:3af3", "ipv4 -value=first-found IPV6 -value can-after=a3a3:a3a3:a3r3:3af3 first-found", false},
-		{"ipv4 -value=first-found IPV6 -value first-found first-found", "IPV4", "first-found", "can-after=a3a3:a3a3:a3r3:3af3", "", true}, // After string not found
-		{"ipv4 -value=first-found IPV6 -value first-found first-found", "IPV6", "not-found", "can-after=a3a3:a3a3:a3r3:3af3", "", true},   // Target string not found after "after"
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("ReplaceAfter(%q, %q, %q, %q)", test.input, test.after, test.target, test.replacement), func(t *testing.T) {
-			actual, err := snaputil.ReplaceAfter(test.input, test.after, test.target, test.replacement)
-
-			if test.errExpected {
-				if err == nil {
-					t.Errorf("Expected an error, but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
-			}
-
-			if actual != test.expected {
-				t.Errorf("Expected %q, but got %q", test.expected, actual)
 			}
 		})
 	}

--- a/pkg/snap/util/calico_test.go
+++ b/pkg/snap/util/calico_test.go
@@ -6,52 +6,56 @@ import (
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
 	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+	. "github.com/onsi/gomega"
 )
 
 func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
-	tests := []struct {
-		name         string
-		cniYaml      string
-		canReachHost string
-		expectedYaml string
+	for _, tc := range []struct {
+		name                 string
+		oldYAML              string
+		canReachHost         string
+		expectYAML           string
+		expectApplyCNICalled int
 	}{
 		{
 			name: "IPv4 Address",
-			cniYaml: `
+			oldYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
 			canReachHost: "10.10.10.10",
-			expectedYaml: `
+			expectYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "can-reach=10.10.10.10"
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
+			expectApplyCNICalled: 1,
 		},
 		{
 			name: "IPv6 Address",
-			cniYaml: `
+			oldYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
 			canReachHost: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-			expectedYaml: `
+			expectYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
   value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`,
+			expectApplyCNICalled: 1,
 		},
 		{
 			name: "IPv4 Address not first-found",
-			cniYaml: `
+			oldYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "can-reach=1.1.1.1"
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
 			canReachHost: "10.10.10.10",
-			expectedYaml: `
+			expectYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "can-reach=1.1.1.1"
 - name: IP6_AUTODETECTION_METHOD
@@ -59,13 +63,13 @@ func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
 		},
 		{
 			name: "IPv6 Address not first-found",
-			cniYaml: `
+			oldYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
   value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`,
 			canReachHost: "2001:0db8:85a3:0000:0000:8a2e:0370:7335",
-			expectedYaml: `
+			expectYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
@@ -73,43 +77,35 @@ func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
 		},
 		{
 			name: "IPv4 Address no autodetection",
-			cniYaml: `
+			oldYAML: `
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
 			canReachHost: "1.1.1.1",
-			expectedYaml: `
+			expectYAML: `
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
 		},
 		{
 			name: "IPv6 Address no autodetection",
-			cniYaml: `
+			oldYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"`,
 			canReachHost: "2001:0db8:85a3:0000:0000:8a2e:0370:7335",
-			expectedYaml: `
+			expectYAML: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"`,
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			snap := &mock.Snap{
-				CNIYaml: test.cniYaml,
+				CNIYaml: tc.oldYAML,
 			}
 
-			if err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, test.canReachHost, true); err != nil {
-				t.Fatalf("Expected no errors but received %q", err)
-			}
-
-			if snap.CNIYaml != test.expectedYaml {
-				t.Fatalf("expected CNI yaml to be %q but it was %q", test.expectedYaml, snap.CNIYaml)
-			}
-
-			if len(snap.ApplyCNICalled) != 1 {
-				t.Fatalf("expected ApplyCNI to be called but it was not")
-			}
+			err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, tc.canReachHost, true)
+			g.Expect(err).To(BeNil())
+			g.Expect(snap.CNIYaml).To(Equal(tc.expectYAML))
+			g.Expect(snap.ApplyCNICalled).To(HaveLen(tc.expectApplyCNICalled))
 		})
 	}
 }

--- a/pkg/snap/util/calico_test.go
+++ b/pkg/snap/util/calico_test.go
@@ -2,6 +2,7 @@ package snaputil_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
@@ -9,40 +10,97 @@ import (
 )
 
 func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
-	snap := &mock.Snap{
-		CNIYaml: `
+	tests := []struct {
+		name         string
+		cniYaml      string
+		canReachHost string
+		expectedYaml string
+	}{
+		{
+			name: "IPv4 Address",
+			cniYaml: `
 - name: IP_AUTODETECTION_METHOD
   value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
   value: "first-found"`,
-	}
-
-	if err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, "10.10.10.10", true); err != nil {
-		t.Fatalf("Expected no errors but received %q", err)
-	}
-
-	expectedYaml := `
+			canReachHost: "10.10.10.10",
+			expectedYaml: `
 - name: IP_AUTODETECTION_METHOD
   value: "can-reach=10.10.10.10"
 - name: IP6_AUTODETECTION_METHOD
-  value: "first-found"`
-	if snap.CNIYaml != expectedYaml {
-		t.Fatalf("expected CNI yaml to be %q but it was %q", expectedYaml, snap.CNIYaml)
-	}
-
-	if err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", true); err != nil {
-		t.Fatalf("Expected no errors but received %q", err)
-	}
-	expectedYaml = `
+  value: "first-found"`,
+		},
+		{
+			name: "IPv6 Address",
+			cniYaml: `
 - name: IP_AUTODETECTION_METHOD
-  value: "can-reach=10.10.10.10"
+  value: value: "first-found"
 - name: IP6_AUTODETECTION_METHOD
-  value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`
-	if snap.CNIYaml != expectedYaml {
-		t.Fatalf("expected CNI yaml to be %q but it was %q", expectedYaml, snap.CNIYaml)
+  value: "first-found"`,
+			canReachHost: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			expectedYaml: `
+- name: IP_AUTODETECTION_METHOD
+  value: value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "can-reach=2001:0db8:85a3:0000:0000:8a2e:0370:7334"`,
+		},
 	}
 
-	if len(snap.ApplyCNICalled) != 2 {
-		t.Fatalf("expected ApplyCNI to be called but it was not")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snap := &mock.Snap{
+				CNIYaml: test.cniYaml,
+			}
+
+			if err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, test.canReachHost, true); err != nil {
+				t.Fatalf("Expected no errors but received %q", err)
+			}
+
+			if snap.CNIYaml != test.expectedYaml {
+				t.Fatalf("expected CNI yaml to be %q but it was %q", test.expectedYaml, snap.CNIYaml)
+			}
+
+			if len(snap.ApplyCNICalled) != 1 {
+				t.Fatalf("expected ApplyCNI to be called but it was not")
+			}
+		})
+	}
+}
+
+func TestReplaceAfter(t *testing.T) {
+	tests := []struct {
+		input       string
+		after       string
+		target      string
+		replacement string
+		expected    string
+		errExpected bool
+	}{
+		// Test cases
+		{"ipv4 -value=first-found IPV6 -value first-found first-found", "IPV6", "first-found", "can-after=a3a3:a3a3:a3r3:3af3", "ipv4 -value=first-found IPV6 -value can-after=a3a3:a3a3:a3r3:3af3 first-found", false},
+		{"ipv4 -value=first-found IPV6 -value first-found first-found", "IPV4", "first-found", "can-after=a3a3:a3a3:a3r3:3af3", "", true}, // After string not found
+		{"ipv4 -value=first-found IPV6 -value first-found first-found", "IPV6", "not-found", "can-after=a3a3:a3a3:a3r3:3af3", "", true},   // Target string not found after "after"
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("ReplaceAfter(%q, %q, %q, %q)", test.input, test.after, test.target, test.replacement), func(t *testing.T) {
+			actual, err := snaputil.ReplaceAfter(test.input, test.after, test.target, test.replacement)
+
+			if test.errExpected {
+				if err == nil {
+					t.Errorf("Expected an error, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if actual != test.expected {
+				t.Errorf("Expected %q, but got %q", test.expected, actual)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Patch the `IP*_AUTODETECTION_METHOD` variable in calico cni based on the IPv* address passes.