### PR TITLE
Fix: missing cni.yaml when using kube-ovn

### DIFF
--- a/pkg/api/v2/join.go
+++ b/pkg/api/v2/join.go
@@ -163,8 +163,10 @@ func (a *API) Join(ctx context.Context, req JoinRequest) (*JoinResponse, int, er
 	}
 
 	a.calicoMu.Lock()
-	if err := snaputil.MaybePatchCalicoAutoDetectionMethod(ctx, a.Snap, remoteIP, true); err != nil {
-		log.Printf("WARNING: failed to update cni configuration: %q", err)
+	if _, err := a.Snap.ReadCNIYaml(); err == nil {
+		if err := snaputil.MaybePatchCalicoAutoDetectionMethod(ctx, a.Snap, remoteIP, true); err != nil {
+			log.Printf("WARNING: failed to update cni configuration: %q", err)
+		}
 	}
 	a.calicoMu.Unlock()
 


### PR DESCRIPTION
Check that we have `cni.yaml` when we are enabling other addons, kube-ovn for example.
Related to: https://github.com/canonical/microk8s/issues/4061 