### PR TITLE
Return custom datastore endpoints if supported by client

### DIFF
--- a/pkg/api/v1/configure.go
+++ b/pkg/api/v1/configure.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 )
 
 // ConfigureServiceRequest is a configuration request for MicroK8s.
@@ -47,7 +47,7 @@ func (a *API) Configure(ctx context.Context, req ConfigureRequest) error {
 		return fmt.Errorf("invalid token")
 	}
 	for _, service := range req.ConfigureServices {
-		if _, err := snaputil.UpdateServiceArguments(a.Snap, service.Name, service.UpdateArguments, service.RemoveArguments); err != nil {
+		if _, err := snap.UpdateServiceArguments(a.Snap, service.Name, service.UpdateArguments, service.RemoveArguments); err != nil {
 			return fmt.Errorf("failed to update arguments of service %q: %w", service.Name, err)
 		}
 		if service.Restart {

--- a/pkg/api/v1/configure_test.go
+++ b/pkg/api/v1/configure_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	v1 "github.com/canonical/microk8s-cluster-agent/pkg/api/v1"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
-	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
 )
 
 func TestConfigure(t *testing.T) {
@@ -73,7 +73,7 @@ func TestConfigure(t *testing.T) {
 			}
 			for serviceName, expectedArguments := range tc.expectedArguments {
 				for key, expectedValue := range expectedArguments {
-					if value := snaputil.GetServiceArgument(s, serviceName, key); value != expectedValue {
+					if value := snap.GetServiceArgument(s, serviceName, key); value != expectedValue {
 						t.Fatalf("Expected argument %q of service %q to be %q, but it is %q", key, serviceName, expectedValue, value)
 					}
 				}

--- a/pkg/api/v1/join.go
+++ b/pkg/api/v1/join.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	"github.com/canonical/microk8s-cluster-agent/pkg/util"
 )
 
@@ -61,9 +61,9 @@ type JoinResponse struct {
 // Join implements "POST /CLUSTER_API_V1/join".
 func (a *API) Join(ctx context.Context, request JoinRequest) (*JoinResponse, error) {
 	response := &JoinResponse{
-		EtcdEndpoint:  snaputil.GetServiceArgument(a.Snap, "etcd", "--listen-client-urls"),
-		APIServerPort: snaputil.GetServiceArgument(a.Snap, "kube-apiserver", "--secure-port"),
-		ClusterCIDR:   snaputil.GetServiceArgument(a.Snap, "kube-proxy", "--cluster-cidr"),
+		EtcdEndpoint:  snap.GetServiceArgument(a.Snap, "etcd", "--listen-client-urls"),
+		APIServerPort: snap.GetServiceArgument(a.Snap, "kube-apiserver", "--secure-port"),
+		ClusterCIDR:   snap.GetServiceArgument(a.Snap, "kube-proxy", "--cluster-cidr"),
 	}
 
 	if !a.Snap.ConsumeClusterToken(request.ClusterToken) {
@@ -102,7 +102,7 @@ func (a *API) Join(ctx context.Context, request JoinRequest) (*JoinResponse, err
 		if err := a.Snap.AddCertificateRequestToken(fmt.Sprintf("%s-kubelet", request.ClusterToken)); err != nil {
 			return nil, fmt.Errorf("failed adding certificate request token for kubelet: %w", err)
 		}
-	case snaputil.GetServiceArgument(a.Snap, "kube-apiserver", "--token-auth-file") != "":
+	case snap.GetServiceArgument(a.Snap, "kube-apiserver", "--token-auth-file") != "":
 		// client does not know how to handle certificate auth, but we have a tokens file
 		response.APIServerAuthMode = APIServerAuthModeToken
 		response.KubeProxyToken, err = a.Snap.GetKnownToken("system:kube-proxy")

--- a/pkg/api/v2/api_util.go
+++ b/pkg/api/v2/api_util.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strings"
 
-	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 )
 
 // findMatchingBindAddress attempts to find the bind address for dqlite from the 'host:port' of the join request.
@@ -70,7 +70,7 @@ nextAddr:
 
 // kubeAPIServerPrefersInternalIPForKubelet checks whether the --kubelet-preferred-address-types of kube-apiserver includes 'InternalIP' with higher preference over 'Hostname'
 func (a *API) kubeAPIServerPrefersInternalIPForKubelet() bool {
-	order := snaputil.GetServiceArgument(a.Snap, "kube-apiserver", "--kubelet-preferred-address-types")
+	order := snap.GetServiceArgument(a.Snap, "kube-apiserver", "--kubelet-preferred-address-types")
 
 	// 'Hostname' has precedence by default, argument must contain 'InternalIP'
 	if ipIndex := strings.Index(order, "InternalIP"); ipIndex != -1 {

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -85,11 +85,11 @@ Role: 0
 	t.Run("NoCertAuthNoTokensFile", func(t *testing.T) {
 		g := NewWithT(t)
 		saveArgs := s.ServiceArguments["kube-apiserver"]
-		s.ServiceArguments["kube-apiserver"] = "--kubelet-preferred-address-types=InternalIP\n--secure-port 16443"
+		s.ServiceArguments["kube-apiserver"] = "--etcd-servers=${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379\n--secure-port 16443"
 		resp, _, err := apiv2.Join(context.Background(), v2.JoinRequest{
 			ClusterToken:     "valid-token-for-auth-test",
 			ClusterAgentPort: "25000",
-			RemoteHostName:   "test-no-cert-auth",
+			RemoteHostName:   "test-no-cert",
 			HostPort:         "10.10.10.10:25000",
 			RemoteAddress:    "10.10.10.14:31312",
 		})
@@ -383,12 +383,13 @@ func TestJoinCustomEtcdEndpoints(t *testing.T) {
 	t.Run("NotSupportedByClient", func(t *testing.T) {
 		g := NewWithT(t)
 		resp, _, err := apiv2.Join(context.Background(), v2.JoinRequest{
-			ClusterToken:     "token-1",
-			RemoteHostName:   "test-1",
-			ClusterAgentPort: "25000",
-			HostPort:         "10.10.10.10:25000",
-			RemoteAddress:    "10.10.10.11:41532",
-			WorkerOnly:       false,
+			ClusterToken:             "token-1",
+			RemoteHostName:           "test-1",
+			ClusterAgentPort:         "25000",
+			HostPort:                 "10.10.10.10:25000",
+			RemoteAddress:            "10.10.10.11:41532",
+			WorkerOnly:               false,
+			CanHandleCertificateAuth: true,
 		})
 		g.Expect(err).NotTo(BeNil())
 		g.Expect(resp).To(BeNil())
@@ -397,13 +398,14 @@ func TestJoinCustomEtcdEndpoints(t *testing.T) {
 	t.Run("SupportedByClient", func(t *testing.T) {
 		g := NewWithT(t)
 		resp, _, err := apiv2.Join(context.Background(), v2.JoinRequest{
-			ClusterToken:        "token-2",
-			RemoteHostName:      "test-2",
-			ClusterAgentPort:    "25000",
-			HostPort:            "10.10.10.10:25000",
-			RemoteAddress:       "10.10.10.12:41532",
-			WorkerOnly:          false,
-			CanHandleCustomEtcd: true,
+			ClusterToken:             "token-2",
+			RemoteHostName:           "test-2",
+			ClusterAgentPort:         "25000",
+			HostPort:                 "10.10.10.10:25000",
+			RemoteAddress:            "10.10.10.12:41532",
+			WorkerOnly:               false,
+			CanHandleCustomEtcd:      true,
+			CanHandleCertificateAuth: true,
 		})
 		g.Expect(err).To(BeNil())
 		g.Expect(resp.EtcdServers).To(Equal("https://etcd1:2379,https://etcd2:2379"))

--- a/pkg/api/v2/join_test.go
+++ b/pkg/api/v2/join_test.go
@@ -46,7 +46,7 @@ Role: 0
 		ServiceAccountKey: "SERVICE ACCOUNT KEY DATA",
 		ServiceArguments: map[string]string{
 			"kubelet":        "kubelet arguments\n",
-			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node,RBAC",
+			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node,RBAC\n--etcd-servers=${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379\n",
 			"kube-proxy":     "--cluster-cidr 10.1.0.0/16",
 			"cluster-agent":  "--bind=0.0.0.0:25000",
 		},
@@ -198,7 +198,7 @@ Role: 0
 		ServiceAccountKey: "SERVICE ACCOUNT KEY DATA",
 		ServiceArguments: map[string]string{
 			"kubelet":        "kubelet arguments\n",
-			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node\n--token-auth-file=known_tokens.csv\n",
+			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node\n--token-auth-file=known_tokens.csv\n--etcd-servers=${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379\n",
 			"kube-proxy":     "--cluster-cidr 10.1.0.0/16",
 			"cluster-agent":  "--bind=0.0.0.0:25000",
 		},
@@ -290,7 +290,7 @@ Role: 0`,
 		ServiceAccountKey: "SERVICE ACCOUNT KEY DATA",
 		ServiceArguments: map[string]string{
 			"kubelet":        "kubelet arguments\n",
-			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node\n--kubelet-preferred-address-types=InternalIP,Hostname\n--token-auth-file=known_tokens.csv\n",
+			"kube-apiserver": "--secure-port 16443\n--authorization-mode=Node\n--kubelet-preferred-address-types=InternalIP,Hostname\n--token-auth-file=known_tokens.csv\n--etcd-servers=${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379\n",
 			"kube-proxy":     "--cluster-cidr 10.1.0.0/16",
 			"cluster-agent":  "--bind=0.0.0.0:25000",
 		},
@@ -347,6 +347,73 @@ Role: 0`,
 	g.Expect(s.ConsumeClusterTokenCalledWith).To(ConsistOf("control-plane-token"))
 	g.Expect(s.ApplyCNICalled).To(HaveLen(1))
 	g.Expect(s.CreateNoCertsReissueLockCalledWith).To(HaveLen(1))
+}
+
+func TestJoinCustomEtcdEndpoints(t *testing.T) {
+	s := &mock.Snap{
+		DqliteLock: true,
+		EtcdCA:     "ETCD CA DATA",
+		EtcdCert:   "ETCD CERTIFICATE DATA",
+		EtcdKey:    "ETCD KEY DATA",
+		ServiceArguments: map[string]string{
+			"kubelet":        "kubelet arguments\n",
+			"kube-apiserver": "--secure-port 16443\n--etcd-servers=https://etcd1:2379,https://etcd2:2379\n",
+			"kube-proxy":     "--cluster-cidr 10.1.0.0/16",
+			"cluster-agent":  "--bind=0.0.0.0:25000",
+		},
+		ClusterTokens: []string{"token-1", "token-2"},
+	}
+
+	apiv2 := &v2.API{
+		Snap: s,
+		LookupIP: func(hostname string) ([]net.IP, error) {
+			return map[string][]net.IP{
+				"test-1": {{10, 10, 10, 11}},
+				"test-2": {{10, 10, 10, 12}},
+			}[hostname], nil
+		},
+		InterfaceAddrs: func() ([]net.Addr, error) {
+			return []net.Addr{
+				&utiltest.MockCIDR{CIDR: "127.0.0.1/8"},
+				&utiltest.MockCIDR{CIDR: "10.10.10.10/16"},
+			}, nil
+		},
+	}
+
+	t.Run("NotSupportedByClient", func(t *testing.T) {
+		g := NewWithT(t)
+		resp, _, err := apiv2.Join(context.Background(), v2.JoinRequest{
+			ClusterToken:     "token-1",
+			RemoteHostName:   "test-1",
+			ClusterAgentPort: "25000",
+			HostPort:         "10.10.10.10:25000",
+			RemoteAddress:    "10.10.10.11:41532",
+			WorkerOnly:       false,
+		})
+		g.Expect(err).NotTo(BeNil())
+		g.Expect(resp).To(BeNil())
+	})
+
+	t.Run("SupportedByClient", func(t *testing.T) {
+		g := NewWithT(t)
+		resp, _, err := apiv2.Join(context.Background(), v2.JoinRequest{
+			ClusterToken:        "token-2",
+			RemoteHostName:      "test-2",
+			ClusterAgentPort:    "25000",
+			HostPort:            "10.10.10.10:25000",
+			RemoteAddress:       "10.10.10.12:41532",
+			WorkerOnly:          false,
+			CanHandleCustomEtcd: true,
+		})
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.EtcdServers).To(Equal("https://etcd1:2379,https://etcd2:2379"))
+		g.Expect(resp.EtcdCertificateAuthority).To(Equal("ETCD CA DATA"))
+		g.Expect(resp.EtcdClientCertificate).To(Equal("ETCD CERTIFICATE DATA"))
+		g.Expect(resp.EtcdClientKey).To(Equal("ETCD KEY DATA"))
+		g.Expect(resp.DqliteClusterCertificate).To(BeEmpty())
+		g.Expect(resp.DqliteClusterKey).To(BeEmpty())
+		g.Expect(resp.DqliteVoterNodes).To(BeEmpty())
+	})
 }
 
 func TestUnmarshalWorkerOnlyField(t *testing.T) {

--- a/pkg/k8sinit/apply.go
+++ b/pkg/k8sinit/apply.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	"github.com/canonical/microk8s-cluster-agent/pkg/util"
 )
 
@@ -148,7 +148,7 @@ func (s *launcherScope) reconcileServiceArgs(ctx context.Context, configFile str
 		}
 	}
 
-	changed, err := snaputil.UpdateServiceArguments(s.launcher.snap, configFile, []map[string]string{updateArgs}, deleteArgs)
+	changed, err := snap.UpdateServiceArguments(s.launcher.snap, configFile, []map[string]string{updateArgs}, deleteArgs)
 	if err != nil {
 		return false, fmt.Errorf("failed to update arguments: %w", err)
 	}

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -106,4 +106,10 @@ type Snap interface {
 
 	// JoinCluster joins the local node to an existing MicroK8s cluster as a control-plane or worker node.
 	JoinCluster(ctx context.Context, url string, worker bool) error
+
+	// ReadEtcdCertificates returns the certificates (CA, certificate, private key) used by kube-apiserver to connect to etcd.
+	// Empty values are returned for certificates that are not used.
+	// An error is returned if any of the certificates is in use cannot be read.
+	// The values returned by this function match the contents of '--etcd-cafile', '--etcd-certfile', '--etcd-keyfile' kube-apiserver arguments respectively.
+	ReadEtcdCertificates() (ca string, cert string, key string, err error)
 }

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -84,6 +84,8 @@ type Snap struct {
 	AddonRepositories map[string]AddonRepository
 
 	JoinClusterCalledWith []JoinClusterCall
+
+	EtcdCA, EtcdCert, EtcdKey string
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.
@@ -338,6 +340,11 @@ func (s *Snap) AddAddonsRepository(ctx context.Context, name, url, reference str
 func (s *Snap) JoinCluster(ctx context.Context, url string, worker bool) error {
 	s.JoinClusterCalledWith = append(s.JoinClusterCalledWith, JoinClusterCall{url, worker})
 	return nil
+}
+
+// ReadEtcdCertificates is a mock implementation for the snap.Snap interface.
+func (s *Snap) ReadEtcdCertificates() (string, string, string, error) {
+	return s.EtcdCA, s.EtcdCert, s.EtcdKey, nil
 }
 
 var _ snap.Snap = &Snap{}

--- a/pkg/snap/services.go
+++ b/pkg/snap/services.go
@@ -1,4 +1,4 @@
-package snaputil
+package snap
 
 import (
 	"errors"
@@ -6,14 +6,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	"github.com/canonical/microk8s-cluster-agent/pkg/util"
 )
 
 // GetServiceArgument retrieves the value of a specific argument from the $SNAP_DATA/args/$service file.
 // The argument name should include preceding dashes (e.g. "--secure-port").
 // If any errors occur, or the argument is not present, an empty string is returned.
-func GetServiceArgument(s snap.Snap, serviceName string, argument string) string {
+func GetServiceArgument(s Snap, serviceName string, argument string) string {
 	arguments, err := s.ReadServiceArguments(serviceName)
 	if err != nil {
 		return ""
@@ -37,7 +36,7 @@ func GetServiceArgument(s snap.Snap, serviceName string, argument string) string
 // updateList is a map of key-value pairs. It will replace the argument with the new value (or just append).
 // delete is a list of arguments to remove completely. The argument is removed if present.
 // Returns a boolean whether any of the arguments were changed, as well as any errors that may have occured.
-func UpdateServiceArguments(s snap.Snap, serviceName string, updateList []map[string]string, delete []string) (bool, error) {
+func UpdateServiceArguments(s Snap, serviceName string, updateList []map[string]string, delete []string) (bool, error) {
 	if updateList == nil {
 		updateList = []map[string]string{}
 	}

--- a/pkg/snap/services_test.go
+++ b/pkg/snap/services_test.go
@@ -1,12 +1,12 @@
-package snaputil_test
+package snap_test
 
 import (
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
-	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
 
 	. "github.com/onsi/gomega"
 )
@@ -48,7 +48,7 @@ func TestGetServiceArgument(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/%s", tc.service, tc.key), func(t *testing.T) {
 			g := NewWithT(t)
 
-			g.Expect(snaputil.GetServiceArgument(s, tc.service, tc.key)).To(Equal(tc.expectedValue))
+			g.Expect(snap.GetServiceArgument(s, tc.service, tc.key)).To(Equal(tc.expectedValue))
 		})
 	}
 }
@@ -69,7 +69,7 @@ func TestUpdateServiceArguments(t *testing.T) {
 			Snap: mock.Snap{},
 		}
 
-		changed, err := snaputil.UpdateServiceArguments(s, "service", []map[string]string{{"--key": "value"}}, nil)
+		changed, err := snap.UpdateServiceArguments(s, "service", []map[string]string{{"--key": "value"}}, nil)
 		g.Expect(err).To(BeNil())
 		g.Expect(changed).To(BeTrue())
 
@@ -172,17 +172,17 @@ func TestUpdateServiceArguments(t *testing.T) {
 				},
 			}
 
-			changed, err := snaputil.UpdateServiceArguments(s, "service", tc.update, tc.delete)
+			changed, err := snap.UpdateServiceArguments(s, "service", tc.update, tc.delete)
 			g.Expect(err).To(BeNil())
 			g.Expect(changed).To(Equal(tc.expectedChange))
 
 			for key, expectedValue := range tc.expectedValues {
-				g.Expect(snaputil.GetServiceArgument(s, "service", key)).To(Equal(expectedValue))
+				g.Expect(snap.GetServiceArgument(s, "service", key)).To(Equal(expectedValue))
 			}
 
 			t.Run("Reapply", func(t *testing.T) {
 				g := NewWithT(t)
-				changed, err := snaputil.UpdateServiceArguments(s, "service", tc.update, tc.delete)
+				changed, err := snap.UpdateServiceArguments(s, "service", tc.update, tc.delete)
 				g.Expect(err).To(BeNil())
 				g.Expect(changed).To(BeFalse())
 			})

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -423,11 +423,11 @@ func (s *snap) ReadEtcdCertificates() (string, string, string, error) {
 			continue
 		}
 
-		if contents, err := util.ReadFile(certFile); err != nil {
+		contents, err := util.ReadFile(certFile)
+		if err != nil {
 			return "", "", "", fmt.Errorf("failed to read %s: %w", cert.arg, err)
-		} else {
-			*cert.dest = contents
 		}
+		*cert.dest = contents
 	}
 
 	return ca, cert, key, nil

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -404,4 +404,33 @@ func (s *snap) JoinCluster(ctx context.Context, url string, worker bool) error {
 	return nil
 }
 
+func (s *snap) ReadEtcdCertificates() (string, string, string, error) {
+	var ca, cert, key string
+	for _, cert := range []struct {
+		dest *string
+		arg  string
+	}{
+		{&ca, "--etcd-cafile"},
+		{&cert, "--etcd-certfile"},
+		{&key, "--etcd-keyfile"},
+	} {
+		certFile := GetServiceArgument(s, "kube-apiserver", cert.arg)
+		certFile = strings.Trim(certFile, "\"")
+		certFile = strings.ReplaceAll(certFile, "$SNAP_DATA", s.snapDataDir)
+		certFile = strings.ReplaceAll(certFile, "${SNAP_DATA}", s.snapDataDir)
+
+		if certFile == "" {
+			continue
+		}
+
+		if contents, err := util.ReadFile(certFile); err != nil {
+			return "", "", "", fmt.Errorf("failed to read %s: %w", cert.arg, err)
+		} else {
+			*cert.dest = contents
+		}
+	}
+
+	return ca, cert, key, nil
+}
+
 var _ Snap = &snap{}


### PR DESCRIPTION
### Summary

If supported by the client (`req.CanHandleCustomEtcd`) and the cluster is using a custom datastore, return the etcd servers and required certificates instead.

### Changes

- Move `GetServiceArgument` to the `snap` package, to avoid cycle dependencies
- Implement `(*Snap).GetEtcdCertificates()` method and add tests
- In `v2/join` endpoint, if the client explicitly states that they support custom datastores, and the configured datastore is not dqlite, then return the etcd servers and certificates (pending client implementation)
- Add unit tests for new behaviour

