### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/ @neoaggelos
+* @neoaggelos


### PR DESCRIPTION
`*` sets the default codeowner - `/` is deprecated.