### PR TITLE
Check if Calico `canReachHost` parameter is valid

### DIFF
--- a/pkg/snap/util/calico.go
+++ b/pkg/snap/util/calico.go
@@ -32,7 +32,11 @@ func MaybePatchCalicoAutoDetectionMethod(ctx context.Context, s snap.Snap, canRe
 	}
 
 	var re *regexp.Regexp
-	if ip := net.ParseIP(canReachHost); ip.To4() == nil {
+	ip := net.ParseIP(canReachHost)
+	if ip == nil {
+			return fmt.Errorf("could not parse IP address %q", canReachHost)
+	}
+	if ip.To4() == nil {
 		// Address is in IPv6
 		re = ip6AutodetectionMethodRe
 	} else {

--- a/pkg/snap/util/calico_test.go
+++ b/pkg/snap/util/calico_test.go
@@ -109,3 +109,19 @@ func TestMaybePatchCalicoAutoDetectionMethod(t *testing.T) {
 		})
 	}
 }
+
+func TestMaybePatchCalicoAutoDetectionMethodBadIP(t *testing.T) {
+	yaml := `
+- name: IP_AUTODETECTION_METHOD
+  value: "first-found"
+- name: IP6_AUTODETECTION_METHOD
+  value: "first-found"`
+	canReachHost := "badIPRepresentation"
+	g := NewWithT(t)
+	snap := &mock.Snap{
+		CNIYaml: yaml,
+	}
+
+	err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, canReachHost, true)
+        g.Expect(err).NotTo(BeNil())
+}


### PR DESCRIPTION
The `canReachHost` represents a string representation of an IP. In the current implementation it is not guaranteed that the passed parameter is actually a valid IP address and would automatically classify it as IPv6.

The function will now check if the IP is valid and return an appropiate error message if not.