### PR TITLE
Add /v2/dqlite/remove endpoint

### DIFF
--- a/pkg/api/v2/register.go
+++ b/pkg/api/v2/register.go
@@ -54,21 +54,21 @@ func (a *API) RegisterServer(server *http.ServeMux, middleware func(f http.Handl
 		httputil.Response(w, map[string]string{"status": "OK"})
 	}))
 
-	// POST v2/remove
-	server.HandleFunc(fmt.Sprintf("%s/remove", HTTPPrefix), middleware(func(w http.ResponseWriter, r *http.Request) {
+	// POST v2/dqlite/remove
+	server.HandleFunc(fmt.Sprintf("%s/dqlite/remove", HTTPPrefix), middleware(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 
-		req := RemoveRequest{}
+		req := RemoveFromDqliteRequest{}
 		if err := httputil.UnmarshalJSON(r, &req); err != nil {
 			httputil.Error(w, http.StatusBadRequest, fmt.Errorf("failed to unmarshal JSON: %w", err))
 			return
 		}
 
-		if rc, err := a.Remove(r.Context(), req); err != nil {
-			httputil.Error(w, rc, fmt.Errorf("failed to remove: %w", err))
+		if rc, err := a.RemoveFromDqlite(r.Context(), req); err != nil {
+			httputil.Error(w, rc, fmt.Errorf("failed to remove from dqlite: %w", err))
 			return
 		}
 

--- a/pkg/api/v2/register.go
+++ b/pkg/api/v2/register.go
@@ -53,4 +53,25 @@ func (a *API) RegisterServer(server *http.ServeMux, middleware func(f http.Handl
 		}
 		httputil.Response(w, map[string]string{"status": "OK"})
 	}))
+
+	// POST v2/remove
+	server.HandleFunc(fmt.Sprintf("%s/remove", HTTPPrefix), middleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		req := RemoveRequest{}
+		if err := httputil.UnmarshalJSON(r, &req); err != nil {
+			httputil.Error(w, http.StatusBadRequest, fmt.Errorf("failed to unmarshal JSON: %w", err))
+			return
+		}
+
+		if rc, err := a.Remove(r.Context(), req); err != nil {
+			httputil.Error(w, rc, fmt.Errorf("failed to remove: %w", err))
+			return
+		}
+
+		httputil.Response(w, nil)
+	}))
 }

--- a/pkg/api/v2/remove.go
+++ b/pkg/api/v2/remove.go
@@ -11,7 +11,7 @@ import (
 // RemoveRequest represents a request to remove a node from the dqlite cluster.
 type RemoveRequest struct {
 	// HostPort is the address of the node to remove.
-	HostPort string
+	HostPort string `json:"hostPort"`
 }
 
 // Remove implements the "POST /v2/remove" endpoint and removes a node from the dqlite cluster.

--- a/pkg/api/v2/remove.go
+++ b/pkg/api/v2/remove.go
@@ -8,15 +8,15 @@ import (
 	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
 )
 
-// RemoveRequest represents a request to remove a node from the dqlite cluster.
-type RemoveRequest struct {
-	// HostPort is the address of the node to remove.
-	HostPort string `json:"hostPort"`
+// RemoveFromDqliteRequest represents a request to remove a node from the dqlite cluster.
+type RemoveFromDqliteRequest struct {
+	// RemoveEndpoint is the endpoint of the node to remove from the dqlite cluster.
+	RemoveEndpoint string `json:"removeEndpoint"`
 }
 
-// Remove implements the "POST /v2/remove" endpoint and removes a node from the dqlite cluster.
-func (a *API) Remove(ctx context.Context, req RemoveRequest) (int, error) {
-	if err := snaputil.RemoveNodeFromDqlite(ctx, a.Snap, req.HostPort); err != nil {
+// RemoveFromDqlite implements the "POST /v2/dqlite/remove" endpoint and removes a node from the dqlite cluster.
+func (a *API) RemoveFromDqlite(ctx context.Context, req RemoveFromDqliteRequest) (int, error) {
+	if err := snaputil.RemoveNodeFromDqlite(ctx, a.Snap, req.RemoveEndpoint); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to remove node from dqlite: %w", err)
 	}
 

--- a/pkg/api/v2/remove.go
+++ b/pkg/api/v2/remove.go
@@ -1,0 +1,24 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+)
+
+// RemoveRequest represents a request to remove a node from the dqlite cluster.
+type RemoveRequest struct {
+	// HostPort is the address of the node to remove.
+	HostPort string
+}
+
+// Remove implements the "POST /v2/remove" endpoint and removes a node from the dqlite cluster.
+func (a *API) Remove(ctx context.Context, req RemoveRequest) (int, error) {
+	if err := snaputil.RemoveNodeFromDqlite(ctx, a.Snap, req.HostPort); err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to remove node from dqlite: %w", err)
+	}
+
+	return http.StatusOK, nil
+}

--- a/pkg/api/v2/remove_test.go
+++ b/pkg/api/v2/remove_test.go
@@ -21,7 +21,7 @@ func TestRemove(t *testing.T) {
 			},
 		}
 
-		rc, err := apiv2.Remove(context.Background(), v2.RemoveRequest{HostPort: "1.1.1.1:1234"})
+		rc, err := apiv2.RemoveFromDqlite(context.Background(), v2.RemoveFromDqliteRequest{RemoveEndpoint: "1.1.1.1:1234"})
 
 		g := NewWithT(t)
 		g.Expect(err).To(MatchError(cmdErr))
@@ -33,7 +33,7 @@ func TestRemove(t *testing.T) {
 			Snap: &mock.Snap{},
 		}
 
-		rc, err := apiv2.Remove(context.Background(), v2.RemoveRequest{HostPort: "1.1.1.1:1234"})
+		rc, err := apiv2.RemoveFromDqlite(context.Background(), v2.RemoveFromDqliteRequest{RemoveEndpoint: "1.1.1.1:1234"})
 
 		g := NewWithT(t)
 		g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/api/v2/remove_test.go
+++ b/pkg/api/v2/remove_test.go
@@ -1,0 +1,42 @@
+package v2_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
+)
+
+func TestRemove(t *testing.T) {
+	t.Run("RemoveFails", func(t *testing.T) {
+		cmdErr := errors.New("failed to run command")
+		apiv2 := &v2.API{
+			Snap: &mock.Snap{
+				RunCommandErr: cmdErr,
+			},
+		}
+
+		rc, err := apiv2.Remove(context.Background(), v2.RemoveRequest{HostPort: "1.1.1.1:1234"})
+
+		g := NewWithT(t)
+		g.Expect(err).To(MatchError(cmdErr))
+		g.Expect(rc).To(Equal(http.StatusInternalServerError))
+	})
+
+	t.Run("RemovesSuccessfully", func(t *testing.T) {
+		apiv2 := &v2.API{
+			Snap: &mock.Snap{},
+		}
+
+		rc, err := apiv2.Remove(context.Background(), v2.RemoveRequest{HostPort: "1.1.1.1:1234"})
+
+		g := NewWithT(t)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rc).To(Equal(http.StatusOK))
+	})
+}

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -7,6 +7,16 @@ import (
 
 // Snap is how the cluster agent interacts with the snap.
 type Snap interface {
+	// GetSnapPath returns the path to a file or directory in the snap directory.
+	GetSnapPath(parts ...string) string
+	// GetSnapDataPath returns the path to a file or directory in the snap's data directory.
+	GetSnapDataPath(parts ...string) string
+	// GetSnapCommonPath returns the path to a file or directory in the snap's common directory.
+	GetSnapCommonPath(parts ...string) string
+
+	// RunCommand runs a shell command.
+	RunCommand(ctx context.Context, commands ...string) error
+
 	// GetGroupName is the group microk8s is using.
 	// The group name is "microk8s" for classic snaps and "snap_microk8s" for strict snaps.
 	GetGroupName() string

--- a/pkg/snap/mock/mock.go
+++ b/pkg/snap/mock/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
@@ -23,8 +24,20 @@ type JoinClusterCall struct {
 	Worker bool
 }
 
+// RunCommandCall contains the arguments passed to a specific call of the RunCommand method.
+type RunCommandCall struct {
+	Commands []string
+}
+
 // Snap is a generic mock for the snap.Snap interface.
 type Snap struct {
+	SnapDir       string
+	SnapDataDir   string
+	SnapCommonDir string
+
+	RunCommandCalledWith []RunCommandCall
+	RunCommandErr        error
+
 	GroupName string
 
 	EnableAddonCalledWith    []string
@@ -86,6 +99,27 @@ type Snap struct {
 	JoinClusterCalledWith []JoinClusterCall
 
 	EtcdCA, EtcdCert, EtcdKey string
+}
+
+// GetSnapPath is a mock implementation for the snap.Snap interface.
+func (s *Snap) GetSnapPath(parts ...string) string {
+	return filepath.Join(append([]string{s.SnapDir}, parts...)...)
+}
+
+// GetSnapDataPath is a mock implementation for the snap.Snap interface.
+func (s *Snap) GetSnapDataPath(parts ...string) string {
+	return filepath.Join(append([]string{s.SnapDataDir}, parts...)...)
+}
+
+// GetSnapCommonPath is a mock implementation for the snap.Snap interface.
+func (s *Snap) GetSnapCommonPath(parts ...string) string {
+	return filepath.Join(append([]string{s.SnapCommonDir}, parts...)...)
+}
+
+// RunCommand is a mock implementation for the snap.Snap interface.
+func (s *Snap) RunCommand(_ context.Context, commands ...string) error {
+	s.RunCommandCalledWith = append(s.RunCommandCalledWith, RunCommandCall{Commands: commands})
+	return s.RunCommandErr
 }
 
 // GetGroupName is a mock implementation for the snap.Snap interface.

--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -51,14 +51,18 @@ func NewSnap(snapDir, snapDataDir, snapCommonDir string, options ...func(s *snap
 
 }
 
-func (s *snap) snapPath(parts ...string) string {
+func (s *snap) RunCommand(ctx context.Context, commands ...string) error {
+	return s.runCommand(ctx, commands...)
+}
+
+func (s *snap) GetSnapPath(parts ...string) string {
 	return filepath.Join(append([]string{s.snapDir}, parts...)...)
 }
 
-func (s *snap) snapDataPath(parts ...string) string {
+func (s *snap) GetSnapDataPath(parts ...string) string {
 	return filepath.Join(append([]string{s.snapDataDir}, parts...)...)
 }
-func (s *snap) snapCommonPath(parts ...string) string {
+func (s *snap) GetSnapCommonPath(parts ...string) string {
 	return filepath.Join(append([]string{s.snapCommonDir}, parts...)...)
 }
 
@@ -70,11 +74,11 @@ func (s *snap) GetGroupName() string {
 }
 
 func (s *snap) EnableAddon(ctx context.Context, addon string, args ...string) error {
-	return s.runCommand(ctx, append([]string{s.snapPath("microk8s-enable.wrapper"), addon}, args...)...)
+	return s.runCommand(ctx, append([]string{s.GetSnapPath("microk8s-enable.wrapper"), addon}, args...)...)
 }
 
 func (s *snap) DisableAddon(ctx context.Context, addon string, args ...string) error {
-	return s.runCommand(ctx, append([]string{s.snapPath("microk8s-disable.wrapper"), addon}, args...)...)
+	return s.runCommand(ctx, append([]string{s.GetSnapPath("microk8s-disable.wrapper"), addon}, args...)...)
 }
 
 type snapcraftYml struct {
@@ -83,7 +87,7 @@ type snapcraftYml struct {
 
 func (s *snap) isStrict() bool {
 	var meta snapcraftYml
-	contents, err := util.ReadFile(s.snapPath("meta", "snapcraft.yaml"))
+	contents, err := util.ReadFile(s.GetSnapPath("meta", "snapcraft.yaml"))
 	if err != nil {
 		return false
 	}
@@ -122,7 +126,7 @@ func (s *snap) RunUpgrade(ctx context.Context, upgrade string, phase string) err
 	default:
 		return fmt.Errorf("unknown upgrade phase %q", phase)
 	}
-	scriptName := s.snapPath("upgrade-scripts", upgrade, fmt.Sprintf("%s-node.sh", phase))
+	scriptName := s.GetSnapPath("upgrade-scripts", upgrade, fmt.Sprintf("%s-node.sh", phase))
 	if !util.FileExists(scriptName) {
 		return fmt.Errorf("could not find script %s", scriptName)
 	}
@@ -133,41 +137,41 @@ func (s *snap) RunUpgrade(ctx context.Context, upgrade string, phase string) err
 }
 
 func (s *snap) ReadCA() (string, error) {
-	return util.ReadFile(s.snapDataPath("certs", "ca.crt"))
+	return util.ReadFile(s.GetSnapDataPath("certs", "ca.crt"))
 }
 
 func (s *snap) ReadCAKey() (string, error) {
-	return util.ReadFile(s.snapDataPath("certs", "ca.key"))
+	return util.ReadFile(s.GetSnapDataPath("certs", "ca.key"))
 }
 
 func (s *snap) GetCAPath() string {
-	return s.snapDataPath("certs", "ca.crt")
+	return s.GetSnapDataPath("certs", "ca.crt")
 }
 
 func (s *snap) GetCAKeyPath() string {
-	return s.snapDataPath("certs", "ca.key")
+	return s.GetSnapDataPath("certs", "ca.key")
 }
 
 func (s *snap) ReadServiceAccountKey() (string, error) {
-	return util.ReadFile(s.snapDataPath("certs", "serviceaccount.key"))
+	return util.ReadFile(s.GetSnapDataPath("certs", "serviceaccount.key"))
 }
 
 func (s *snap) GetCNIYamlPath() string {
-	return s.snapDataPath("args", "cni-network", "cni.yaml")
+	return s.GetSnapDataPath("args", "cni-network", "cni.yaml")
 }
 
 func (s *snap) ReadCNIYaml() (string, error) {
-	return util.ReadFile(s.snapDataPath("args", "cni-network", "cni.yaml"))
+	return util.ReadFile(s.GetSnapDataPath("args", "cni-network", "cni.yaml"))
 }
 
 func (s *snap) WriteCNIYaml(cniManifest []byte) error {
-	return os.WriteFile(s.snapDataPath("args", "cni-network", "cni.yaml"), []byte(cniManifest), 0660)
+	return os.WriteFile(s.GetSnapDataPath("args", "cni-network", "cni.yaml"), []byte(cniManifest), 0660)
 }
 
 func (s *snap) ApplyCNI(ctx context.Context) error {
 	var err error
 	for i := 0; i < s.applyCNIRetries; i++ {
-		if err = s.runCommand(ctx, s.snapPath("microk8s-kubectl.wrapper"), "apply", "-f", s.GetCNIYamlPath()); err == nil {
+		if err = s.runCommand(ctx, s.GetSnapPath("microk8s-kubectl.wrapper"), "apply", "-f", s.GetCNIYamlPath()); err == nil {
 			return nil
 		}
 		time.Sleep(s.applyCNIBackoff)
@@ -176,61 +180,61 @@ func (s *snap) ApplyCNI(ctx context.Context) error {
 }
 
 func (s *snap) ReadDqliteCert() (string, error) {
-	return util.ReadFile(s.snapDataPath("var", "kubernetes", "backend", "cluster.crt"))
+	return util.ReadFile(s.GetSnapDataPath("var", "kubernetes", "backend", "cluster.crt"))
 }
 
 func (s *snap) ReadDqliteKey() (string, error) {
-	return util.ReadFile(s.snapDataPath("var", "kubernetes", "backend", "cluster.key"))
+	return util.ReadFile(s.GetSnapDataPath("var", "kubernetes", "backend", "cluster.key"))
 }
 
 func (s *snap) ReadDqliteInfoYaml() (string, error) {
-	return util.ReadFile(s.snapDataPath("var", "kubernetes", "backend", "info.yaml"))
+	return util.ReadFile(s.GetSnapDataPath("var", "kubernetes", "backend", "info.yaml"))
 }
 
 func (s *snap) ReadDqliteClusterYaml() (string, error) {
-	return util.ReadFile(s.snapDataPath("var", "kubernetes", "backend", "cluster.yaml"))
+	return util.ReadFile(s.GetSnapDataPath("var", "kubernetes", "backend", "cluster.yaml"))
 }
 
 func (s *snap) WriteDqliteUpdateYaml(updateYaml []byte) error {
-	return os.WriteFile(s.snapDataPath("var", "kubernetes", "backend", "update.yaml"), updateYaml, 0660)
+	return os.WriteFile(s.GetSnapDataPath("var", "kubernetes", "backend", "update.yaml"), updateYaml, 0660)
 }
 
 func (s *snap) GetKubeconfigFile() string {
-	return s.snapDataPath("credentials", "client.config")
+	return s.GetSnapDataPath("credentials", "client.config")
 }
 
 func (s *snap) HasKubeliteLock() bool {
-	return util.FileExists(s.snapDataPath("var", "lock", "lite.lock"))
+	return util.FileExists(s.GetSnapDataPath("var", "lock", "lite.lock"))
 }
 
 func (s *snap) HasDqliteLock() bool {
-	return util.FileExists(s.snapDataPath("var", "lock", "ha-cluster"))
+	return util.FileExists(s.GetSnapDataPath("var", "lock", "ha-cluster"))
 }
 
 func (s *snap) HasNoCertsReissueLock() bool {
-	return util.FileExists(s.snapDataPath("var", "lock", "no-cert-reissue"))
+	return util.FileExists(s.GetSnapDataPath("var", "lock", "no-cert-reissue"))
 }
 
 func (s *snap) CreateNoCertsReissueLock() error {
-	_, err := os.OpenFile(s.snapDataPath("var", "lock", "no-cert-reissue"), os.O_CREATE, 0600)
+	_, err := os.OpenFile(s.GetSnapDataPath("var", "lock", "no-cert-reissue"), os.O_CREATE, 0600)
 	return err
 }
 
 func (s *snap) ReadServiceArguments(serviceName string) (string, error) {
-	return util.ReadFile(s.snapDataPath("args", serviceName))
+	return util.ReadFile(s.GetSnapDataPath("args", serviceName))
 }
 
 func (s *snap) WriteServiceArguments(serviceName string, arguments []byte) error {
-	return os.WriteFile(s.snapDataPath("args", serviceName), arguments, 0660)
+	return os.WriteFile(s.GetSnapDataPath("args", serviceName), arguments, 0660)
 }
 
 func (s *snap) ConsumeClusterToken(token string) bool {
 	s.clusterTokensMu.Lock()
 	defer s.clusterTokensMu.Unlock()
-	if isValid, _ := util.IsValidToken(token, s.snapDataPath("credentials", "persistent-cluster-tokens.txt")); isValid {
+	if isValid, _ := util.IsValidToken(token, s.GetSnapDataPath("credentials", "persistent-cluster-tokens.txt")); isValid {
 		return true
 	}
-	clusterTokensFile := s.snapDataPath("credentials", "cluster-tokens.txt")
+	clusterTokensFile := s.GetSnapDataPath("credentials", "cluster-tokens.txt")
 	isValid, hasTTL := util.IsValidToken(token, clusterTokensFile)
 	if isValid && !hasTTL {
 		if err := util.RemoveToken(token, clusterTokensFile, s.GetGroupName()); err != nil {
@@ -243,7 +247,7 @@ func (s *snap) ConsumeClusterToken(token string) bool {
 func (s *snap) ConsumeCertificateRequestToken(token string) bool {
 	s.certTokensMu.Lock()
 	defer s.certTokensMu.Unlock()
-	certRequestTokensFile := s.snapDataPath("credentials", "certs-request-tokens.txt")
+	certRequestTokensFile := s.GetSnapDataPath("credentials", "certs-request-tokens.txt")
 	isValid, _ := util.IsValidToken(token, certRequestTokensFile)
 	if isValid {
 		if err := util.RemoveToken(token, certRequestTokensFile, s.GetGroupName()); err != nil {
@@ -254,32 +258,32 @@ func (s *snap) ConsumeCertificateRequestToken(token string) bool {
 }
 
 func (s *snap) ConsumeSelfCallbackToken(token string) bool {
-	valid, _ := util.IsValidToken(token, s.snapDataPath("credentials", "callback-token.txt"))
+	valid, _ := util.IsValidToken(token, s.GetSnapDataPath("credentials", "callback-token.txt"))
 	return valid
 }
 
 func (s *snap) AddPersistentClusterToken(token string) error {
 	s.certTokensMu.Lock()
 	defer s.certTokensMu.Unlock()
-	return util.AppendToken(token, s.snapDataPath("credentials", "persistent-cluster-tokens.txt"), s.GetGroupName())
+	return util.AppendToken(token, s.GetSnapDataPath("credentials", "persistent-cluster-tokens.txt"), s.GetGroupName())
 }
 
 func (s *snap) AddCertificateRequestToken(token string) error {
 	s.certTokensMu.Lock()
 	defer s.certTokensMu.Unlock()
-	return util.AppendToken(token, s.snapDataPath("credentials", "certs-request-tokens.txt"), s.GetGroupName())
+	return util.AppendToken(token, s.GetSnapDataPath("credentials", "certs-request-tokens.txt"), s.GetGroupName())
 }
 
 func (s *snap) AddCallbackToken(clusterAgentEndpoint string, token string) error {
 	s.callbackTokensMu.Lock()
 	defer s.callbackTokensMu.Unlock()
-	return util.AppendToken(fmt.Sprintf("%s %s", clusterAgentEndpoint, token), s.snapDataPath("credentials", "callback-tokens.txt"), s.GetGroupName())
+	return util.AppendToken(fmt.Sprintf("%s %s", clusterAgentEndpoint, token), s.GetSnapDataPath("credentials", "callback-tokens.txt"), s.GetGroupName())
 }
 
 func (s *snap) GetOrCreateSelfCallbackToken() (string, error) {
 	s.callbackTokensMu.Lock()
 	defer s.callbackTokensMu.Unlock()
-	callbackTokenFile := s.snapDataPath("credentials", "callback-token.txt")
+	callbackTokenFile := s.GetSnapDataPath("credentials", "callback-token.txt")
 	c, err := util.ReadFile(callbackTokenFile)
 	if err != nil {
 		token := util.NewRandomString(util.Alpha, 64)
@@ -303,7 +307,7 @@ func (s *snap) GetOrCreateKubeletToken(hostname string) (string, error) {
 
 	s.knownTokensMu.Lock()
 	defer s.knownTokensMu.Unlock()
-	if err := util.AppendToken(fmt.Sprintf("%s,%s,kubelet-%s,\"system:nodes\"", token, user, uid), s.snapDataPath("credentials", "known_tokens.csv"), s.GetGroupName()); err != nil {
+	if err := util.AppendToken(fmt.Sprintf("%s,%s,kubelet-%s,\"system:nodes\"", token, user, uid), s.GetSnapDataPath("credentials", "known_tokens.csv"), s.GetGroupName()); err != nil {
 		return "", fmt.Errorf("failed to add new kubelet token for %s: %w", user, err)
 	}
 
@@ -313,7 +317,7 @@ func (s *snap) GetOrCreateKubeletToken(hostname string) (string, error) {
 func (s *snap) GetKnownToken(username string) (string, error) {
 	s.knownTokensMu.Lock()
 	defer s.knownTokensMu.Unlock()
-	allTokens, err := util.ReadFile(s.snapDataPath("credentials", "known_tokens.csv"))
+	allTokens, err := util.ReadFile(s.GetSnapDataPath("credentials", "known_tokens.csv"))
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve known token for user %s: %w", username, err)
 	}
@@ -330,7 +334,7 @@ func (s *snap) GetKnownToken(username string) (string, error) {
 func (s *snap) SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, error) {
 	// TODO: consider using crypto/x509 for this instead of relying on openssl commands.
 	// NOTE(neoaggelos): x509.CreateCertificate() has some hardcoded fields that are incompatible with MicroK8s.
-	signCmd := exec.CommandContext(ctx, s.snapPath("actions", "common", "utils.sh"), "sign_certificate")
+	signCmd := exec.CommandContext(ctx, s.GetSnapPath("actions", "common", "utils.sh"), "sign_certificate")
 	signCmd.Stdin = bytes.NewBuffer(csrPEM)
 	stdout := &bytes.Buffer{}
 	signCmd.Stdout = stdout
@@ -342,9 +346,9 @@ func (s *snap) SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, erro
 
 func (s *snap) ImportImage(ctx context.Context, reader io.Reader) error {
 	importCmd := exec.CommandContext(ctx,
-		s.snapPath("bin", "ctr"),
+		s.GetSnapPath("bin", "ctr"),
 		"--namespace", "k8s.io",
-		"--address", s.snapCommonPath("run", "containerd.sock"),
+		"--address", s.GetSnapCommonPath("run", "containerd.sock"),
 		"image",
 		"import",
 		"--platform", runtime.GOARCH,
@@ -361,11 +365,11 @@ func (s *snap) ImportImage(ctx context.Context, reader io.Reader) error {
 }
 
 func (s *snap) WriteCSRConfig(csrConf []byte) error {
-	return os.WriteFile(s.snapDataPath("certs", "csr.conf.template"), csrConf, 0660)
+	return os.WriteFile(s.GetSnapDataPath("certs", "csr.conf.template"), csrConf, 0660)
 }
 
 func (s *snap) UpdateContainerdRegistryConfigs(configs map[string][]byte) error {
-	relativeHostsDir := s.snapDataPath("args", "certs.d")
+	relativeHostsDir := s.GetSnapDataPath("args", "certs.d")
 	hostsDir, err := filepath.Abs(relativeHostsDir)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute directory for registry configurations: %w", err)
@@ -393,7 +397,7 @@ func (s *snap) UpdateContainerdRegistryConfigs(configs map[string][]byte) error 
 }
 
 func (s *snap) AddAddonsRepository(ctx context.Context, name, url, reference string, force bool) error {
-	cmd := []string{filepath.Join(s.snapPath("microk8s-addons.wrapper")), "repo", "add", name, url}
+	cmd := []string{filepath.Join(s.GetSnapPath("microk8s-addons.wrapper")), "repo", "add", name, url}
 	if reference != "" {
 		cmd = append(cmd, "--reference", reference)
 	}
@@ -407,7 +411,7 @@ func (s *snap) AddAddonsRepository(ctx context.Context, name, url, reference str
 }
 
 func (s *snap) JoinCluster(ctx context.Context, url string, worker bool) error {
-	cmd := []string{filepath.Join(s.snapPath("microk8s-join.wrapper")), url}
+	cmd := []string{filepath.Join(s.GetSnapPath("microk8s-join.wrapper")), url}
 	if worker {
 		cmd = append(cmd, "--worker")
 	}

--- a/pkg/snap/util/calico.go
+++ b/pkg/snap/util/calico.go
@@ -34,7 +34,7 @@ func MaybePatchCalicoAutoDetectionMethod(ctx context.Context, s snap.Snap, canRe
 	var re *regexp.Regexp
 	ip := net.ParseIP(canReachHost)
 	if ip == nil {
-			return fmt.Errorf("could not parse IP address %q", canReachHost)
+		return fmt.Errorf("could not parse IP address %q", canReachHost)
 	}
 	if ip.To4() == nil {
 		// Address is in IPv6

--- a/pkg/snap/util/calico_test.go
+++ b/pkg/snap/util/calico_test.go
@@ -123,5 +123,5 @@ func TestMaybePatchCalicoAutoDetectionMethodBadIP(t *testing.T) {
 	}
 
 	err := snaputil.MaybePatchCalicoAutoDetectionMethod(context.Background(), snap, canReachHost, true)
-        g.Expect(err).NotTo(BeNil())
+	g.Expect(err).NotTo(BeNil())
 }

--- a/pkg/snap/util/dqlite.go
+++ b/pkg/snap/util/dqlite.go
@@ -139,7 +139,7 @@ func RemoveNodeFromDqlite(ctx context.Context, snap snap.Snap, removeEp string) 
 	clusterCrtPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.crt")
 	clusterKeyPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.key")
 
-	if err := snap.RunCommand(ctx, binPath, "-s", "file://"+clusterYamlPath, "-c", clusterCrtPath, "-k", clusterKeyPath, "-f", "json", "k8s", ".remove", removeEp); err != nil {
+	if err := snap.RunCommand(ctx, binPath, "-s", "file://"+clusterYamlPath, "-c", clusterCrtPath, "-k", clusterKeyPath, "-f", "json", "k8s", fmt.Sprintf(".remove %s", removeEp)); err != nil {
 		return fmt.Errorf("failed to run remove command: %w", err)
 	}
 

--- a/pkg/snap/util/dqlite.go
+++ b/pkg/snap/util/dqlite.go
@@ -133,13 +133,13 @@ func MaybeUpdateDqliteBindAddress(ctx context.Context, snap snap.Snap, hostPort 
 }
 
 // RemoveNodeFromDqlite uses the Dqlite binary to remove a node from the Dqlite cluster.
-func RemoveNodeFromDqlite(ctx context.Context, snap snap.Snap, hostPort string) error {
+func RemoveNodeFromDqlite(ctx context.Context, snap snap.Snap, removeEp string) error {
 	binPath := snap.GetSnapPath("bin", "dqlite")
 	clusterYamlPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.yaml")
 	clusterCrtPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.crt")
 	clusterKeyPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.key")
 
-	if err := snap.RunCommand(ctx, binPath, "-s", "file://"+clusterYamlPath, "-c", clusterCrtPath, "-k", clusterKeyPath, "-f", "json", "k8s", ".remove", hostPort); err != nil {
+	if err := snap.RunCommand(ctx, binPath, "-s", "file://"+clusterYamlPath, "-c", clusterCrtPath, "-k", clusterKeyPath, "-f", "json", "k8s", ".remove", removeEp); err != nil {
 		return fmt.Errorf("failed to run remove command: %w", err)
 	}
 

--- a/pkg/snap/util/dqlite.go
+++ b/pkg/snap/util/dqlite.go
@@ -139,6 +139,7 @@ func RemoveNodeFromDqlite(ctx context.Context, snap snap.Snap, removeEp string) 
 	clusterCrtPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.crt")
 	clusterKeyPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.key")
 
+	// NOTE(Hue): The last two arguments (.remove <address>) should be a single string. Otherwise Dqlite throws an error.
 	if err := snap.RunCommand(ctx, binPath, "-s", "file://"+clusterYamlPath, "-c", clusterCrtPath, "-k", clusterKeyPath, "-f", "json", "k8s", fmt.Sprintf(".remove %s", removeEp)); err != nil {
 		return fmt.Errorf("failed to run remove command: %w", err)
 	}

--- a/pkg/snap/util/dqlite.go
+++ b/pkg/snap/util/dqlite.go
@@ -131,3 +131,17 @@ func MaybeUpdateDqliteBindAddress(ctx context.Context, snap snap.Snap, hostPort 
 	}
 	return nil
 }
+
+// RemoveNodeFromDqlite uses the Dqlite binary to remove a node from the Dqlite cluster.
+func RemoveNodeFromDqlite(ctx context.Context, snap snap.Snap, hostPort string) error {
+	binPath := snap.GetSnapPath("bin", "dqlite")
+	clusterYamlPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.yaml")
+	clusterCrtPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.crt")
+	clusterKeyPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.key")
+
+	if err := snap.RunCommand(ctx, binPath, "-s", "file://"+clusterYamlPath, "-c", clusterCrtPath, "-k", clusterKeyPath, "-f", "json", "k8s", ".remove", hostPort); err != nil {
+		return fmt.Errorf("failed to run remove command: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/snap/util/dqlite_test.go
+++ b/pkg/snap/util/dqlite_test.go
@@ -3,6 +3,7 @@ package snaputil_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -189,6 +190,6 @@ func TestRemoveNodeFromDqlite(t *testing.T) {
 		g := NewWithT(t)
 		g.Expect(snaputil.RemoveNodeFromDqlite(context.Background(), s, removeEp)).To(Succeed())
 		g.Expect(s.RunCommandCalledWith).To(HaveLen(1))
-		g.Expect(s.RunCommandCalledWith[0].Commands).To(ContainElements(ContainSubstring(snapDir), ContainSubstring(snapDataDir), removeEp))
+		g.Expect(s.RunCommandCalledWith[0].Commands).To(ContainElements(ContainSubstring(snapDir), ContainSubstring(snapDataDir), fmt.Sprintf(".remove %s", removeEp)))
 	})
 }

--- a/pkg/snap/util/dqlite_test.go
+++ b/pkg/snap/util/dqlite_test.go
@@ -179,7 +179,7 @@ func TestRemoveNodeFromDqlite(t *testing.T) {
 	t.Run("CommandRunsSuccessfully", func(t *testing.T) {
 		snapDir := "/snapDir"
 		snapDataDir := "/snapDataDir"
-		hostPort := "1.1.1.1:1234"
+		removeEp := "1.1.1.1:1234"
 
 		s := &mock.Snap{
 			SnapDir:     snapDir,
@@ -187,8 +187,8 @@ func TestRemoveNodeFromDqlite(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		g.Expect(snaputil.RemoveNodeFromDqlite(context.Background(), s, hostPort)).To(Succeed())
+		g.Expect(snaputil.RemoveNodeFromDqlite(context.Background(), s, removeEp)).To(Succeed())
 		g.Expect(s.RunCommandCalledWith).To(HaveLen(1))
-		g.Expect(s.RunCommandCalledWith[0].Commands).To(ContainElements(ContainSubstring(snapDir), ContainSubstring(snapDataDir), hostPort))
+		g.Expect(s.RunCommandCalledWith[0].Commands).To(ContainElements(ContainSubstring(snapDir), ContainSubstring(snapDataDir), removeEp))
 	})
 }

--- a/pkg/util/token.go
+++ b/pkg/util/token.go
@@ -40,8 +40,8 @@ func NewRandomString(letters RandomCharacters, length int) string {
 // A token may optionally have a TTL, which is appended at the end of the token.
 // For example, the tokens file may look like this:
 //
-//     token1
-//     token2|35616531876
+//	token1
+//	token2|35616531876
 //
 // In the file above, token1 is a valid token. token2 is valid until the unix timestamp 35616531876.
 func IsValidToken(token string, tokensFile string) (isValidToken, hasTTL bool) {


### PR DESCRIPTION
### Summary
In the Microk8s CAPI provider, when we're removing a node, we're not removing it from the Dqlite cluster. This Results in a situation where a a node's IP remains in the `${SNAP_DATA}/var/kubernetes/backend/cluster.yaml` even after its departure from the cluster. This is problematic by nature, specially in scenarios where we might a have a joining node with an IP that previously belonged to a now deleted node (like CAPI). In this PR we add a `/v2/remove` endpoint that the CAPI controllers can call in order to remove an entry from Dqlite.

### Notes to the reviewers
1. This implementation ignores any sort of security as the endpoint can be called from anywhere. Further security considerations should be implemented in the follow up PRs.
2. The implementation has design/implementation flaws and is not aligned with my personal preferences. Yet it's the best/most-efficient way that I could think of given the importance of Microk8s and its CAPI at the moment. As an example:
    - The `RemoveNodeFromDqlite` is fundamentally questionable and disregards many well-known good practices, yet it's aligned with the current layout of the repo. The initial implementation that I went with was (IMO) more technically correct/robust and maintainable, but needed considerable amount of changes __and__ was in disagreement with the layout/codestyle of the repo. Not even mentioning the fact that we're calling a binary which we can't by any means have access to from this project, other than crazy mockings, making e2e tests infeasible.  

### How to test
Sorry, you can't. Not from this repo.