### PR TITLE
[Backport to 1.28] Add Dqlite Remove Endpoint

### DIFF
--- a/pkg/api/v2/consts.go
+++ b/pkg/api/v2/consts.go
@@ -1,0 +1,6 @@
+package v2
+
+const (
+	// CAPIAuthTokenHeader is the header used to pass the CAPI auth token.
+	CAPIAuthTokenHeader = "capi-auth-token"
+)

--- a/pkg/api/v2/register.go
+++ b/pkg/api/v2/register.go
@@ -53,4 +53,27 @@ func (a *API) RegisterServer(server *http.ServeMux, middleware func(f http.Handl
 		}
 		httputil.Response(w, map[string]string{"status": "OK"})
 	}))
+
+	// POST v2/dqlite/remove
+	server.HandleFunc(fmt.Sprintf("%s/dqlite/remove", HTTPPrefix), middleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		req := RemoveFromDqliteRequest{}
+		if err := httputil.UnmarshalJSON(r, &req); err != nil {
+			httputil.Error(w, http.StatusBadRequest, fmt.Errorf("failed to unmarshal JSON: %w", err))
+			return
+		}
+
+		token := r.Header.Get(CAPIAuthTokenHeader)
+
+		if rc, err := a.RemoveFromDqlite(r.Context(), req, token); err != nil {
+			httputil.Error(w, rc, fmt.Errorf("failed to remove from dqlite: %w", err))
+			return
+		}
+
+		httputil.Response(w, nil)
+	}))
 }

--- a/pkg/api/v2/remove.go
+++ b/pkg/api/v2/remove.go
@@ -1,0 +1,33 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
+)
+
+// RemoveFromDqliteRequest represents a request to remove a node from the dqlite cluster.
+type RemoveFromDqliteRequest struct {
+	// RemoveEndpoint is the endpoint of the node to remove from the dqlite cluster.
+	RemoveEndpoint string `json:"remove_endpoint"`
+}
+
+// RemoveFromDqlite implements the "POST /v2/dqlite/remove" endpoint and removes a node from the dqlite cluster.
+func (a *API) RemoveFromDqlite(ctx context.Context, req RemoveFromDqliteRequest, token string) (int, error) {
+	isValid, err := a.Snap.IsCAPIAuthTokenValid(token)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to validate CAPI auth token: %w", err)
+	}
+
+	if !isValid {
+		return http.StatusUnauthorized, fmt.Errorf("invalid CAPI auth token %q", token)
+	}
+
+	if err := snaputil.RemoveNodeFromDqlite(ctx, a.Snap, req.RemoveEndpoint); err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to remove node from dqlite: %w", err)
+	}
+
+	return http.StatusOK, nil
+}

--- a/pkg/api/v2/remove_test.go
+++ b/pkg/api/v2/remove_test.go
@@ -1,0 +1,74 @@
+package v2_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	v2 "github.com/canonical/microk8s-cluster-agent/pkg/api/v2"
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
+)
+
+func TestRemove(t *testing.T) {
+	t.Run("RemoveFails", func(t *testing.T) {
+		cmdErr := errors.New("failed to run command")
+		apiv2 := &v2.API{
+			Snap: &mock.Snap{
+				RunCommandErr:      cmdErr,
+				CAPIAuthTokenValid: true,
+			},
+		}
+
+		rc, err := apiv2.RemoveFromDqlite(context.Background(), v2.RemoveFromDqliteRequest{RemoveEndpoint: "1.1.1.1:1234"}, "token")
+
+		g := NewWithT(t)
+		g.Expect(err).To(MatchError(cmdErr))
+		g.Expect(rc).To(Equal(http.StatusInternalServerError))
+	})
+
+	t.Run("InvalidToken", func(t *testing.T) {
+		apiv2 := &v2.API{
+			Snap: &mock.Snap{
+				CAPIAuthTokenValid: false, // explicitly set to false
+			},
+		}
+
+		rc, err := apiv2.RemoveFromDqlite(context.Background(), v2.RemoveFromDqliteRequest{RemoveEndpoint: "1.1.1.1:1234"}, "token")
+
+		g := NewWithT(t)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(rc).To(Equal(http.StatusUnauthorized))
+	})
+
+	t.Run("TokenFileNotFound", func(t *testing.T) {
+		tokenErr := errors.New("token file not found")
+		apiv2 := &v2.API{
+			Snap: &mock.Snap{
+				CAPIAuthTokenError: tokenErr,
+			},
+		}
+
+		rc, err := apiv2.RemoveFromDqlite(context.Background(), v2.RemoveFromDqliteRequest{RemoveEndpoint: "1.1.1.1:1234"}, "token")
+
+		g := NewWithT(t)
+		g.Expect(err).To(MatchError(tokenErr))
+		g.Expect(rc).To(Equal(http.StatusInternalServerError))
+	})
+
+	t.Run("RemovesSuccessfully", func(t *testing.T) {
+		apiv2 := &v2.API{
+			Snap: &mock.Snap{
+				CAPIAuthTokenValid: true,
+			},
+		}
+
+		rc, err := apiv2.RemoveFromDqlite(context.Background(), v2.RemoveFromDqliteRequest{RemoveEndpoint: "1.1.1.1:1234"}, "token")
+
+		g := NewWithT(t)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rc).To(Equal(http.StatusOK))
+	})
+}

--- a/pkg/snap/interface.go
+++ b/pkg/snap/interface.go
@@ -7,6 +7,18 @@ import (
 
 // Snap is how the cluster agent interacts with the snap.
 type Snap interface {
+	// GetSnapPath returns the path to a file or directory in the snap directory.
+	GetSnapPath(parts ...string) string
+	// GetSnapDataPath returns the path to a file or directory in the snap's data directory.
+	GetSnapDataPath(parts ...string) string
+	// GetSnapCommonPath returns the path to a file or directory in the snap's common directory.
+	GetSnapCommonPath(parts ...string) string
+	// GetCAPIPath returns the path to a file or directory in the CAPI directory.
+	GetCAPIPath(parts ...string) string
+
+	// RunCommand runs a shell command.
+	RunCommand(ctx context.Context, commands ...string) error
+
 	// GetGroupName is the group microk8s is using.
 	// The group name is "microk8s" for classic snaps and "snap_microk8s" for strict snaps.
 	GetGroupName() string
@@ -87,6 +99,9 @@ type Snap interface {
 	GetOrCreateKubeletToken(hostname string) (string, error)
 	// GetKnownToken returns the token for a known user from the known_users.csv file.
 	GetKnownToken(username string) (string, error)
+
+	// IsCAPIAuthTokenValid returns true if token is a valid CAPI auth token.
+	IsCAPIAuthTokenValid(token string) (bool, error)
 
 	// SignCertificate signs the certificate signing request, and returns the certificate in PEM format.
 	SignCertificate(ctx context.Context, csrPEM []byte) ([]byte, error)

--- a/pkg/snap/options.go
+++ b/pkg/snap/options.go
@@ -22,3 +22,10 @@ func WithCommandRunner(f func(context.Context, ...string) error) func(s *snap) {
 		s.runCommand = f
 	}
 }
+
+// WithCAPIPath configures the path to the CAPI directory.
+func WithCAPIPath(path string) func(s *snap) {
+	return func(s *snap) {
+		s.capiPath = path
+	}
+}

--- a/pkg/snap/snap_capi_token_test.go
+++ b/pkg/snap/snap_capi_token_test.go
@@ -1,0 +1,37 @@
+package snap_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/canonical/microk8s-cluster-agent/pkg/snap"
+)
+
+func TestCAPIAuthToken(t *testing.T) {
+	capiTestPath := "./capi-test"
+	os.RemoveAll(capiTestPath)
+	s := snap.NewSnap("", "", "", snap.WithCAPIPath(capiTestPath))
+	token := "token123"
+
+	g := NewWithT(t)
+
+	isValid, err := s.IsCAPIAuthTokenValid(token)
+	g.Expect(err).To(MatchError(os.ErrNotExist))
+	g.Expect(isValid).To(BeFalse())
+
+	capiEtc := filepath.Join(capiTestPath, "etc")
+	defer os.RemoveAll(capiTestPath)
+	g.Expect(os.MkdirAll(capiEtc, 0755)).To(Succeed())
+	g.Expect(os.WriteFile("./capi-test/etc/token", []byte(token), 0600)).To(Succeed())
+
+	isValid, err = s.IsCAPIAuthTokenValid("random-token")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(isValid).To(BeFalse())
+
+	isValid, err = s.IsCAPIAuthTokenValid(token)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(isValid).To(BeTrue())
+}

--- a/pkg/snap/util/dqlite.go
+++ b/pkg/snap/util/dqlite.go
@@ -95,3 +95,18 @@ func WaitForDqliteCluster(ctx context.Context, s snap.Snap, f func(DqliteCluster
 		}
 	}
 }
+
+// RemoveNodeFromDqlite uses the Dqlite binary to remove a node from the Dqlite cluster.
+func RemoveNodeFromDqlite(ctx context.Context, snap snap.Snap, removeEp string) error {
+	binPath := snap.GetSnapPath("bin", "dqlite")
+	clusterYamlPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.yaml")
+	clusterCrtPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.crt")
+	clusterKeyPath := snap.GetSnapDataPath("var", "kubernetes", "backend", "cluster.key")
+
+	// NOTE(Hue): The last two arguments (.remove <address>) should be a single string. Otherwise Dqlite throws an error.
+	if err := snap.RunCommand(ctx, binPath, "-s", "file://"+clusterYamlPath, "-c", clusterCrtPath, "-k", clusterKeyPath, "-f", "json", "k8s", fmt.Sprintf(".remove %s", removeEp)); err != nil {
+		return fmt.Errorf("failed to run remove command: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/snap/util/dqlite_test.go
+++ b/pkg/snap/util/dqlite_test.go
@@ -2,9 +2,13 @@ package snaputil_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/canonical/microk8s-cluster-agent/pkg/snap/mock"
 	snaputil "github.com/canonical/microk8s-cluster-agent/pkg/snap/util"
@@ -83,4 +87,34 @@ Role: 0`,
 		}
 	})
 
+}
+
+func TestRemoveNodeFromDqlite(t *testing.T) {
+	t.Run("CommandFails", func(t *testing.T) {
+		cmdErr := errors.New("failed to run command")
+		s := &mock.Snap{
+			RunCommandErr: cmdErr,
+		}
+
+		err := snaputil.RemoveNodeFromDqlite(context.Background(), s, "1.1.1.1:1234")
+
+		g := NewWithT(t)
+		g.Expect(err).To(MatchError(cmdErr))
+	})
+
+	t.Run("CommandRunsSuccessfully", func(t *testing.T) {
+		snapDir := "/snapDir"
+		snapDataDir := "/snapDataDir"
+		removeEp := "1.1.1.1:1234"
+
+		s := &mock.Snap{
+			SnapDir:     snapDir,
+			SnapDataDir: snapDataDir,
+		}
+
+		g := NewWithT(t)
+		g.Expect(snaputil.RemoveNodeFromDqlite(context.Background(), s, removeEp)).To(Succeed())
+		g.Expect(s.RunCommandCalledWith).To(HaveLen(1))
+		g.Expect(s.RunCommandCalledWith[0].Commands).To(ContainElements(ContainSubstring(snapDir), ContainSubstring(snapDataDir), fmt.Sprintf(".remove %s", removeEp)))
+	})
 }

--- a/pkg/util/token.go
+++ b/pkg/util/token.go
@@ -40,8 +40,8 @@ func NewRandomString(letters RandomCharacters, length int) string {
 // A token may optionally have a TTL, which is appended at the end of the token.
 // For example, the tokens file may look like this:
 //
-//     token1
-//     token2|35616531876
+//	token1
+//	token2|35616531876
 //
 // In the file above, token1 is a valid token. token2 is valid until the unix timestamp 35616531876.
 func IsValidToken(token string, tokensFile string) (isValidToken, hasTTL bool) {


### PR DESCRIPTION
### Overview
This PR backports the `dqlite-remove-endpoint`-related changes from `main` to `1.28`:

* Add Dqlite Remove Endpoint (#57)