### PR TITLE
Fix write to provider.yaml file

### DIFF
--- a/pkg/proxy/internal/util.go
+++ b/pkg/proxy/internal/util.go
@@ -64,10 +64,14 @@ func writeYaml(file string, data interface{}) error {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
 
 	if _, err := tmpFile.Write(b); err != nil {
+		tmpFile.Close()
 		return fmt.Errorf("failed to write to temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 
 	if err := os.Rename(tmpFile.Name(), file); err != nil {

--- a/pkg/proxy/internal/util.go
+++ b/pkg/proxy/internal/util.go
@@ -47,6 +47,17 @@ func writeYaml(file string, data interface{}) error {
 		return fmt.Errorf("failed to marshal yaml: %w", err)
 	}
 
+	// NOTE(Hue): This is technically not a good thing to do here,
+	// because for whatever reason we might *want* to write an empty file.
+	// And we're also making this function context aware (read coupled)
+	// which is not a good thing.
+	// However, since this function is **only** used to write `provider.yaml` file and
+	// we know we don't want that file to be empty, we can safely return an error here.
+	// Make sure to remove this check if the above statement is no longer true.
+	if data == nil || len(b) == 0 {
+		return fmt.Errorf("empty yaml data")
+	}
+
 	dir := filepath.Dir(file)
 	tmpFile, err := os.CreateTemp(dir, "tmp-*")
 	if err != nil {

--- a/pkg/proxy/internal/util.go
+++ b/pkg/proxy/internal/util.go
@@ -64,14 +64,10 @@ func writeYaml(file string, data interface{}) error {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	if _, err := tmpFile.Write(b); err != nil {
-		tmpFile.Close()
 		return fmt.Errorf("failed to write to temp file: %w", err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 
 	if err := os.Rename(tmpFile.Name(), file); err != nil {

--- a/pkg/proxy/internal/util_test.go
+++ b/pkg/proxy/internal/util_test.go
@@ -2,7 +2,9 @@ package internal
 
 import (
 	"os"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestGetDefaultProviderFile(t *testing.T) {
@@ -34,4 +36,48 @@ func TestGetDefaultProviderFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteFile(t *testing.T) {
+	file, err := os.CreateTemp("", "test-*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+
+	const numWriters = 100
+	const numIterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numWriters)
+
+	// The data to write to the file
+	testData := map[string]interface{}{
+		"key": "value",
+	}
+
+	for i := 0; i < numWriters; i++ {
+		go func(writerID int) {
+			defer wg.Done()
+
+			for j := 0; j < numIterations; j++ {
+				if err := writeYaml(file.Name(), testData); err != nil {
+					t.Errorf("Writer %d failed to write yaml (iteration %d): %v", writerID, j, err)
+				}
+
+				content, err := os.ReadFile(file.Name())
+				if err != nil {
+					t.Errorf("Writer %d failed to read file (iteration %d): %v", writerID, j, err)
+				}
+
+				if string(content) != "key: value\n" {
+					t.Errorf("Writer %d: Invalid content (iteration %d): %s", writerID, j, string(content))
+				}
+
+				time.Sleep(10 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/pkg/proxy/internal/util_test.go
+++ b/pkg/proxy/internal/util_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 )
@@ -60,8 +59,8 @@ func TestWriteFile(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		const (
-			numWriters    = 100
-			numIterations = 100
+			numWriters    = 200
+			numIterations = 200
 		)
 
 		var wg sync.WaitGroup
@@ -82,8 +81,6 @@ func TestWriteFile(t *testing.T) {
 					content, err := os.ReadFile(file.Name())
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(string(content)).To(Equal("key: value\n"))
-
-					time.Sleep(10 * time.Millisecond)
 				}
 			}(i)
 		}


### PR DESCRIPTION
### Overview
Fixes (hopefully) https://github.com/canonical/microk8s/issues/4197
According to this issue, sometimes the `traefik/provider.yaml` ends up empty on worker nodes. I investigated this and the only place that seems to change this file is the cluster-agent `UpdateConfiguration` which does the update upon receiving new Kubernetes endpoints.
I was not able to reproduce the issue but according to the logs reported by other people this change might solve the issue. Also the [`rm` seems to be atomic] and we should not end up with empty files (failed writes).
Quoting from https://github.com/canonical/microk8s/issues/4197#issuecomment-2416046939:
```
microk8s.daemon-apiserver-proxy[252757]: 2024/10/16 00:10:32 updating endpoints
microk8s.daemon-apiserver-proxy[252757]: 2024/10/16 00:10:32 Config file changed on disk, will restart proxy
microk8s.daemon-apiserver-proxy[252757]: Error: proxy failed: failed to load configuration: empty list of control plane endpoints
microk8s.daemon-apiserver-proxy[252757]: 2024/10/16 00:10:32 proxy failed: accept tcp [::]:16443: use of closed network connection
```
The "updating endpoints" can be seen right before ending up with an empty file.

[`rm` seems to be atomic]: https://stackoverflow.com/questions/18706419/is-a-move-operation-in-unix-atomic#:~:text=The%20UNIX%20mv%20command%20uses,(which%20is%20not%20atomic).