### PR TITLE
chore: branch out 1.34

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -2,8 +2,7 @@ name: cla-check
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [1.34]
 
 permissions:
   contents: read


### PR DESCRIPTION
## chore: branch out 1.34

This PR branches out the 1.34 release.